### PR TITLE
Handle double inclusion of the header gracefully

### DIFF
--- a/include/exml.hrl
+++ b/include/exml.hrl
@@ -1,3 +1,6 @@
+-ifndef(EXML_HEADER).
+-define(EXML_HEADER, true).
+
 -type xmlattr() :: {binary(), binary()}.
 
 -record(xmlcdata, {content = [] :: iodata()}).
@@ -7,3 +10,5 @@
                 children =  [] :: [#xmlel{} | #xmlcdata{}]}).
 
 -type xmlterm() :: #xmlel{} | xmlattr() | #xmlcdata{}.
+
+-endif.


### PR DESCRIPTION
If both `include/exml_stream.hrl` and `include/exml.hrl` are included, than we will get an error.
This patch fixes this behaviour.
