### PR TITLE
exml_event.c: enif_open_resource_type for "parser_pointer" does not specify the destructor function.

### DIFF
--- a/c_src/exml_event.c
+++ b/c_src/exml_event.c
@@ -155,7 +155,6 @@ static ERL_NIF_TERM new_parser(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
     *xml_parser = parser;
     parser_resource = enif_make_resource(env, (void *)xml_parser);
     enif_release_resource(xml_parser);
-    printf("exml_event->new_parser( Env: %p ...); [ type: %p; Res: %lu; pParser: %p ]\r\n", env, PARSER_POINTER, parser_resource, xml_parser );
     return enif_make_tuple(env, 2, OK, parser_resource);
 };
 
@@ -181,14 +180,12 @@ static ERL_NIF_TERM reset_parser(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 
 static void parser_dtor( ErlNifEnv *env, void* obj )
 {
-    printf( "exml_event->parser_dtor( Env: %p; pParser:%p ) [ type: %p ]\r\n", env, obj, PARSER_POINTER );
     XML_Parser* pParser = (XML_Parser*) obj;
     if (!pParser)
         return;
 
     expat_parser* parser_data;
     parser_data = XML_GetUserData( *pParser );
-    printf("\tparser_data: %p\r\n", parser_data );
 
     enif_free( parser_data );
     parser_data = NULL;
@@ -199,20 +196,7 @@ static void parser_dtor( ErlNifEnv *env, void* obj )
 
 static ERL_NIF_TERM free_parser(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
-    // XML_Parser **parser;
-
-    // assert(argc == 1);
-    // printf( "exml_event->free_parser( Env: %p; Res:%lu ) [ type: %p ]\r\n", env, (ERL_NIF_TERM)(argv[0]), PARSER_POINTER );
-
-    // if (!enif_get_resource(env, argv[0], PARSER_POINTER, (void **)&parser))
-    //     return enif_make_badarg(env);
-
-    // expat_parser *parser_data = XML_GetUserData((XML_Parser)(*parser));
-    // enif_free(parser_data);
-
-    // XML_ParserFree((XML_Parser)(*parser));
-
-    return OK;
+    return reset_parser( env, argc, argv );
 };
 
 static ERL_NIF_TERM parse(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -256,7 +240,6 @@ static int load(ErlNifEnv* env, void **priv, ERL_NIF_TERM info)
     PARSER_POINTER = enif_open_resource_type(env, NULL, "parser_pointer", &parser_dtor,
                                              ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER,
                                              NULL);
-
     XML_ELEMENT_START = enif_make_atom(env, "xml_element_start");
     XML_ELEMENT_END = enif_make_atom(env, "xml_element_end");
     XML_CDATA = enif_make_atom(env, "xml_cdata");


### PR DESCRIPTION
The following snippet contains some helper funs I would like to use to demonstrate the issue.
Just paste them into your REPL: https://gist.github.com/RGafiyatullin/675b97dc76c69d8a7c00 .

The leaky case (current `esl/master`): https://gist.github.com/RGafiyatullin/9cefce33bb22f3350cf0 .
The fixed case (current `RGafiyatullin/master`): https://gist.github.com/RGafiyatullin/4b895d6282b43d78dc42 .

Bits of reasoning:
- The mandatory `exml_event:free_parser/1` usage is not an option as it is a slightly less expected behaviour rather than a proper resource cleanup upon garbage collection. (The iodevices / ets's / dets's / you-name-it's usually get disposed upon the owner's termination ).
- `exml_event:free_parser/1` being bound to `exml_event:reset_parser/1` is IMHO a necessity since any attempt to use `exml_event:parse/2` with the resource being previously freed leads to a VM crash. The ErlangVM is not expected to crash with a segfault in case of a mistake in Erlang code.
