### PR TITLE
Escape attr value when converting to iolist

### DIFF
--- a/src/exml.erl
+++ b/src/exml.erl
@@ -98,7 +98,7 @@ to_pretty_iolist(#xmlcdata{content = Content}, Level, Indent) ->
 attrs_to_iolist([], Acc) ->
     Acc;
 attrs_to_iolist([{Name, Value} | Rest], Acc) ->
-    attrs_to_iolist(Rest, [" ", Name, "='", Value, "'" | Acc]).
+    attrs_to_iolist(Rest, [" ", Name, "='", escape_attr(Value), "'" | Acc]).
 
 -spec parse(binary()) -> {ok, #xmlel{}} | {error, any()}.
 parse(XML) ->

--- a/test/exml_stream_tests.erl
+++ b/test/exml_stream_tests.erl
@@ -121,3 +121,20 @@ cdata_test() ->
     assert_parses_escape_cdata(<<"><tag">>),
     assert_parses_escape_cdata(<<"<!--">>),
     assert_parses_escape_cdata(<<"<![CDATA[ test">>).
+
+-define(ATTR_TEST_STREAM, <<"<stream:stream xmlns:stream='something'><quote attr=\"&amp;&lt;&gt;&quot;&apos;&#xA;&#x9;&#xD;\"/></stream:stream>">>).
+
+conv_attr_test() ->
+    AssertParses = fun(Input) ->
+                           {ok, Parser0} = exml_stream:new_parser(),
+                           {ok, Parser1, Elements} = exml_stream:parse(Parser0, Input),
+                           ok = exml_stream:free_parser(Parser1),
+                           ?assertMatch([_, #xmlel{attrs = [{<<"attr">>, <<"&<>\"'\n\t\r">>}]} | _],
+                                                   Elements),
+                           Elements
+                   end,
+    Elements = AssertParses(?ATTR_TEST_STREAM),
+    AssertParses(exml:to_binary(Elements)),
+    AssertParses(list_to_binary(exml:to_list(Elements))),
+    AssertParses(list_to_binary(exml:to_iolist(Elements))).
+


### PR DESCRIPTION
Addresses this: https://github.com/esl/exml/issues/9

This reuses escape_attr NIF to escape attribute values when converting to iolist. This function escapes both single and double quotes. Since we always convert to a value enclosed in single quotes, we don't need to escape double quotes, but not sure it's worth it to modify or create a separate NIF just for this purpose.