### PR TITLE
Support OTP 18 and 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
 notifications:
         email: mongoose-im@erlang-solutions.com
 otp_release:
+        - 18.2.1
         - 17.0
         - R16B03
         - R16B02

--- a/rebar.test.config
+++ b/rebar.test.config
@@ -12,5 +12,5 @@
 {cover_export_enabled, true}.
 
 {deps,
- [{proper, ".*", {git, "git://github.com/manopapad/proper.git", {tag, "v1.1"}}},
+ [{proper, ".*", {git, "git://github.com/manopapad/proper.git", {tag, "v1.2"}}},
   {ecoveralls, ".*", {git, "https://github.com/nifoc/ecoveralls.git"}}]}.


### PR DESCRIPTION
OTP 19 looks not being available on Travis CI yet, but I ran `make && make dialyzer && make test` locally with 19.0.2.