### PR TITLE
Mac OS X build improved

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -24,9 +24,10 @@ all: $(C_SRC_OUTPUT)
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	# It's a bit non-standard for a Makefile but OSX users will appreciate
+	CFLAGS += -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -arch x86_64 -finline-functions -Wall
+	LDFLAGS += -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION
This PR changes the way `LDFLAGS`, `CFLAGS` and `CXXFLAGS` from environment are used. It is common for Makefiles to have the env. vars. replace predefined ones inside Makefile but Mac users often have these vars set to bypass Mac strange/outdated libraries, like OpenSSL.