### PR TITLE
re-enabled cover in tests

### DIFF
--- a/rebar.test.config
+++ b/rebar.test.config
@@ -10,6 +10,11 @@
 {post_hooks,
  [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
   {"(freebsd)", clean, "gmake -C c_src clean"}]}.
+
 {cover_enabled, true}.
+{cover_print_enabled, true}.
+{cover_export_enabled, true}.
+
 {deps,
- [{proper, ".*", {git, "git://github.com/manopapad/proper.git", {tag, "v1.2"}}}]}.
+ [{proper, ".*", {git, "git://github.com/manopapad/proper.git", {tag, "v1.2"}}},
+  {ecoveralls, ".*", {git, "https://github.com/nifoc/ecoveralls.git"}}]}.


### PR DESCRIPTION
Cover stats in tests were accidentally disabled with some previous changes. This PR re-enables them. 