### PR TITLE
Element with ns selector

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,3 +14,7 @@
 {cover_print_enabled, true}.
 {cover_export_enabled, true}.
 
+{profiles,
+ [{test,
+   [{deps, [{proper, "1.2.0"}]}]
+  }]}.

--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -12,6 +12,7 @@
 -export([subelement/2, subelement/3]).
 -export([subelement_with_ns/2, subelement_with_ns/3]).
 -export([subelements/2]).
+-export([subelements_with_ns/2]).
 -export([attr/2, attr/3]).
 -export([cdata/1]).
 
@@ -47,6 +48,9 @@ paths(#xmlel{} = Element, []) ->
     [Element];
 paths(#xmlel{} = Element, [{element, Name} | Rest]) ->
     Children = subelements(Element, Name),
+    lists:append([paths(Child, Rest) || Child <- Children]);
+paths(#xmlel{} = Element, [{element_with_ns, NS} | Rest]) ->
+    Children = subelements_with_ns(Element, NS),
     lists:append([paths(Child, Rest) || Child <- Children]);
 paths(#xmlel{} = Element, [cdata]) ->
     [cdata(Element)];
@@ -92,6 +96,14 @@ child_with_ns([_ | Rest], NS, Default) ->
 subelements(#xmlel{children = Children}, Name) ->
     lists:filter(fun(#xmlel{name = N}) when N =:= Name ->
                         true;
+                    (_) ->
+                        false
+                 end, Children).
+
+-spec subelements_with_ns(exml:element(), binary()) -> [exml:element()].
+subelements_with_ns(#xmlel{children = Children}, NS) ->
+    lists:filter(fun(#xmlel{} = Child) ->
+                        NS =:= attr(Child, <<"xmlns">>);
                     (_) ->
                         false
                  end, Children).

--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -10,11 +10,13 @@
 -export([path/2, path/3]).
 -export([paths/2]).
 -export([subelement/2, subelement/3]).
+-export([subelement_with_ns/2, subelement_with_ns/3]).
 -export([subelements/2]).
 -export([attr/2, attr/3]).
 -export([cdata/1]).
 
--type path() :: [cdata | {element, binary()} | {attr, binary()}].
+-type path() :: [cdata | {element, binary()} | {attr, binary()}
+                 | {element_with_ns, binary()}].
 -export_type([path/0]).
 
 %% @doc gets the element/attr/cdata contained in the leftmost path
@@ -28,6 +30,9 @@ path(#xmlel{} = Element, [], _) ->
     Element;
 path(#xmlel{} = Element, [{element, Name} | Rest], Default) ->
     Child = subelement(Element, Name), % may return undefined
+    path(Child, Rest, Default);
+path(#xmlel{} = Element, [{element_with_ns, NS} | Rest], Default) ->
+    Child = subelement_with_ns(Element, NS),
     path(Child, Rest, Default);
 path(#xmlel{} = Element, [cdata], _) ->
     cdata(Element);
@@ -62,6 +67,26 @@ subelement(#xmlel{children = Children}, Name, Default) ->
         Result ->
             Result
     end.
+
+-spec subelement_with_ns(exml:element(), binary()) -> exml:element() | undefined.
+subelement_with_ns(Element, NS) ->
+    subelement_with_ns(Element, NS, undefined).
+
+-spec subelement_with_ns(exml:element(), binary(), Other) -> exml:element() | Other.
+subelement_with_ns(#xmlel{children = Children}, NS, Default) ->
+    child_with_ns(Children, NS, Default).
+
+child_with_ns([], _, Default) ->
+    Default;
+child_with_ns([#xmlel{} = Element | Rest], NS, Default) ->
+    case attr(Element, <<"xmlns">>) of
+        NS ->
+            Element;
+        _ ->
+            child_with_ns(Rest, NS, Default)
+    end;
+child_with_ns([_ | Rest], NS, Default) ->
+    child_with_ns(Rest, NS, Default).
 
 -spec subelements(exml:element(), binary()) -> [exml:element()].
 subelements(#xmlel{children = Children}, Name) ->

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -45,6 +45,25 @@ elements_query_test() ->
                 xml(<<"<problem no='3'>is too big</problem>">>)],
     ?assertEqual(Exemplar, exml_query:subelements(?MY_SPOON, <<"problem">>)).
 
+element_with_ns_query_test() ->
+    ?assertEqual(xml(<<"<received xmlns='urn:xmpp:chat-markers:0'
+                                id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>)">>),
+                 exml_query:subelement_with_ns(chat_marker(),
+                                               <<"urn:xmpp:chat-markers:0">>)).
+
+no_element_with_ns_query_test() ->
+    ?assertEqual(none,
+                 exml_query:subelement_with_ns(chat_marker(),
+                                               <<"wrong">>, none)).
+chat_marker() ->
+    Stanza =
+    <<"<message from='bOb93.499106@localhost/res1'
+                to='alicE93.499106@localhost/res1' xml:lang='en'>
+          <received xmlns='urn:xmpp:chat-markers:0'
+                    id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>
+    </message>">>,
+    xml(Stanza).
+
 attribute_query_test() ->
     ?assertEqual(<<"my">>, exml_query:attr(?MY_SPOON, <<"whose">>)),
     ?assertEqual(<<"my">>, exml_query:path(?MY_SPOON, [{attr, <<"whose">>}])),

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -13,9 +13,9 @@
 -compile(export_all).
 
 -define(MY_SPOON, xml(<<"<spoon whose='my'>",
-                          "<problem no='1'>is too big</problem>",
-                          "<problem no='2'>is too big</problem>",
-                          "<problem no='3'>is too big</problem>",
+                          "<problem no='1' xmlns='urn:issues'>is too big</problem>",
+                          "<problem no='2' xmlns='urn:issues'>is too big</problem>",
+                          "<problem no='3' xmlns='urn:accidents'>is too big</problem>",
                         "</spoon>">>)).
 -define (HTML, xml(<<"<html>
                           <li>
@@ -34,15 +34,15 @@
 
 element_query_test() ->
     %% we return only the first (leftmost) match
-    ?assertEqual(xml(<<"<problem no='1'>is too big</problem>">>),
+    ?assertEqual(xml(<<"<problem no='1' xmlns='urn:issues'>is too big</problem>">>),
                  exml_query:subelement(?MY_SPOON, <<"problem">>)),
-    ?assertEqual(xml(<<"<problem no='1'>is too big</problem>">>),
+    ?assertEqual(xml(<<"<problem no='1' xmlns='urn:issues'>is too big</problem>">>),
                  exml_query:path(?MY_SPOON, [{element, <<"problem">>}])).
 
 elements_query_test() ->
-    Exemplar = [xml(<<"<problem no='1'>is too big</problem>">>),
-                xml(<<"<problem no='2'>is too big</problem>">>),
-                xml(<<"<problem no='3'>is too big</problem>">>)],
+    Exemplar = [xml(<<"<problem no='1' xmlns='urn:issues'>is too big</problem>">>),
+                xml(<<"<problem no='2' xmlns='urn:issues'>is too big</problem>">>),
+                xml(<<"<problem no='3' xmlns='urn:accidents'>is too big</problem>">>)],
     ?assertEqual(Exemplar, exml_query:subelements(?MY_SPOON, <<"problem">>)).
 
 element_with_ns_query_test() ->
@@ -108,6 +108,9 @@ path_query_test() ->
     ?assertEqual(<<"1">>,
                  exml_query:path(?MY_SPOON, [{element, <<"problem">>},
                                              {attr, <<"no">>}])),
+    ?assertEqual(<<"3">>,
+                 exml_query:path(?MY_SPOON, [{element_with_ns, <<"urn:accidents">>},
+                                             {attr, <<"no">>}])),
 
     %% I couldn't find anything complex enough in that silly cartoon :[
     Qux = xml(<<"<foo><bar><baz a='b'>qux</baz></bar></foo>">>),
@@ -132,6 +135,9 @@ paths_query_test() ->
                                                cdata])),
     ?assertEqual([<<"1">>, <<"2">>, <<"3">>],
                  exml_query:paths(?MY_SPOON, [{element, <<"problem">>},
+                                              {attr, <<"no">>}])),
+    ?assertEqual([<<"1">>, <<"2">>],
+                 exml_query:paths(?MY_SPOON, [{element_with_ns, <<"urn:issues">>},
                                               {attr, <<"no">>}])),
     ?assertEqual([], exml_query:paths(?MY_SPOON, [{element, <<"banana">>}])),
     ?assertEqual([<<"My">>, <<"spoon">>, <<"is">>],

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -55,12 +55,36 @@ no_element_with_ns_query_test() ->
     ?assertEqual(none,
                  exml_query:subelement_with_ns(chat_marker(),
                                                <<"wrong">>, none)).
+
+elements_with_ns_query_test() ->
+    ValidResult = [
+                   xml(<<"<received xmlns='urn:xmpp:chat-markers:0'
+                                id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>)">>),
+                   xml(<<"<displayed xmlns='urn:xmpp:chat-markers:0'
+                                id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>">>)
+                  ],
+    ?assertEqual(ValidResult, exml_query:subelements_with_ns(chat_markers(),
+                                                             <<"urn:xmpp:chat-markers:0">>)).
+
 chat_marker() ->
     Stanza =
     <<"<message from='bOb93.499106@localhost/res1'
                 to='alicE93.499106@localhost/res1' xml:lang='en'>
           <received xmlns='urn:xmpp:chat-markers:0'
                     id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>
+    </message>">>,
+    xml(Stanza).
+
+%% There shouldn't be more than one chat marker in single message
+%% but hey, it's a test to verify a function, right?
+chat_markers() ->
+    Stanza =
+    <<"<message from='bOb93.499106@localhost/res1'
+                to='alicE93.499106@localhost/res1' xml:lang='en'>
+          <received xmlns='urn:xmpp:chat-markers:0'
+                    id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>
+          <displayed xmlns='urn:xmpp:chat-markers:0'
+                    id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>
     </message>">>,
     xml(Stanza).
 


### PR DESCRIPTION
This PR implements `{element_with_ns, NS}` selector. It returns the leftmost element with `xmlns` attribute matching provided namespace.

Refers to #27
