### PR TITLE
Element with name and namespace selector

### DIFF
--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -49,7 +49,12 @@ element_with_ns_query_test() ->
     ?assertEqual(xml(<<"<received xmlns='urn:xmpp:chat-markers:0'
                                 id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>)">>),
                  exml_query:subelement_with_ns(chat_marker(),
-                                               <<"urn:xmpp:chat-markers:0">>)).
+                                               <<"urn:xmpp:chat-markers:0">>)),
+
+    ?assertEqual(xml(<<"<received xmlns='urn:xmpp:chat-markers:0'
+                                id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>)">>),
+                 exml_query:path(chat_marker(),
+                                 [{element_with_ns, <<"urn:xmpp:chat-markers:0">>}])).
 
 no_element_with_ns_query_test() ->
     ?assertEqual(none,
@@ -64,7 +69,9 @@ elements_with_ns_query_test() ->
                                 id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>">>)
                   ],
     ?assertEqual(ValidResult, exml_query:subelements_with_ns(chat_markers(),
-                                                             <<"urn:xmpp:chat-markers:0">>)).
+                                                             <<"urn:xmpp:chat-markers:0">>)),
+    ?assertEqual(ValidResult, exml_query:paths(chat_markers(),
+                                               [{element_with_ns, <<"urn:xmpp:chat-markers:0">>}])).
 
 chat_marker() ->
     Stanza =

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -73,6 +73,37 @@ elements_with_ns_query_test() ->
     ?assertEqual(ValidResult, exml_query:paths(chat_markers(),
                                                [{element_with_ns, <<"urn:xmpp:chat-markers:0">>}])).
 
+element_with_name_and_ns_query_test() ->
+    ValidResult = xml(<<"<displayed xmlns='urn:xmpp:chat-markers:0'
+                                id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>">>),
+    ?assertEqual(ValidResult, exml_query:subelement_with_name_and_ns(chat_markers(),
+                                                                     <<"displayed">>,
+                                                                     <<"urn:xmpp:chat-markers:0">>)),
+    ?assertEqual(ValidResult, exml_query:path(chat_markers(),
+                                              [{element_with_ns, <<"displayed">>,
+                                               <<"urn:xmpp:chat-markers:0">>}])).
+
+no_element_with_name_and_ns_query_test() ->
+    ?assertEqual(none,
+                 exml_query:subelement_with_name_and_ns(chat_marker(),
+                                                        <<"wrong">>, <<"urn:xmpp:chat-markers:0">>,
+                                                        none)),
+    ?assertEqual(none,
+                 exml_query:subelement_with_name_and_ns(chat_marker(),
+                                                        <<"received">>, <<"wrong:xmpp:chat-markers:0">>,
+                                                        none)).
+elements_with_name_and_ns_query_test() ->
+    ValidResult = [
+                   xml(<<"<item xmlns='urn:xmpp:chat-markers:0'
+                                id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>)">>),
+                   xml(<<"<item xmlns='urn:xmpp:chat-markers:0'
+                                id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>">>)
+                  ],
+    ?assertEqual(ValidResult, exml_query:subelements_with_name_and_ns(items_with_ns(), <<"item">>,
+                                                                      <<"urn:xmpp:chat-markers:0">>)),
+    ?assertEqual(ValidResult, exml_query:paths(items_with_ns(),
+                                               [{element_with_ns, <<"item">>,
+                                                 <<"urn:xmpp:chat-markers:0">>}])).
 chat_marker() ->
     Stanza =
     <<"<message from='bOb93.499106@localhost/res1'
@@ -91,6 +122,21 @@ chat_markers() ->
           <received xmlns='urn:xmpp:chat-markers:0'
                     id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>
           <displayed xmlns='urn:xmpp:chat-markers:0'
+                    id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>
+    </message>">>,
+    xml(Stanza).
+
+items_with_ns() ->
+    Stanza =
+    <<"<message from='bOb93.499106@localhost/res1'
+                to='alicE93.499106@localhost/res1' xml:lang='en'>
+          <item xmlns='urn:xmpp:chat-markers:0'
+                    id='0047ee62-9418-4ef8-abd8-0d08e4140b72'/>
+          <item xmlns='urn:xmpp:chat-markers:0'
+                    id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>
+          <item xmlns='wrong:xmpp:chat-markers:0'
+                    id='0e3urn00615-7a77-4b5e-91c5-52d8c44149cf'/>
+          <item2 xmlns='urn:xmpp:chat-markers:0'
                     id='0e300615-7a77-4b5e-91c5-52d8c44149cf'/>
     </message>">>,
     xml(Stanza).


### PR DESCRIPTION
This PR add one more selector to exml_query: `{element_with_ns, Name, NS}`. It matches all elements with given name and namespace.

This again, partially addresses #27 