### PR TITLE
Add a macro for asserting if two xmlel's are equal

### DIFF
--- a/include/exml.hrl
+++ b/include/exml.hrl
@@ -1,3 +1,8 @@
+%%%-------------------------------------------------------------------
+%%% Parts of this file, explicitly marked in the code, were taken from
+%%% https://github.com/erszcz/rxml
+%%%-------------------------------------------------------------------
+
 -ifndef(EXML_HEADER).
 -define(EXML_HEADER, true).
 
@@ -6,5 +11,23 @@
 -record(xmlel, {name :: binary(),
                 attrs = [] :: [exml:attr()],
                 children =  [] :: [exml:element() | exml:cdata()]}).
+
+%% Implementation of the exmlAssertEqual/2 macro is an exact copy of
+%% https://github.com/erszcz/rxml/commit/e8483408663f0bc2af7896e786c1cdea2e86e43d#diff-2cb5d18741df32f4ead70c21fdd221d1
+%% See assertEqual in $ERLANG/lib/stdlib-2.6/include/assert.hrl for the original.
+-define(exmlAssertEqual(Example, Expr),
+        begin
+            ((fun (__E, __V) ->
+                      case __V of
+                          __E -> ok;
+                          __V -> erlang:error({exmlAssertEqual,
+                                               [{module, ?MODULE},
+                                                {line, ?LINE},
+                                                {expression, (??Expr)},
+                                                {expected, __E},
+                                                {value, __V}]})
+                      end
+              end)(exml:xml_sort((Example)), exml:xml_sort((Expr))))
+        end).
 
 -endif.

--- a/test/exml_tests.erl
+++ b/test/exml_tests.erl
@@ -32,6 +32,93 @@ size_of_exml_with_cdata_test() ->
             use double dashes as much as I want (along with <, &, ', and \")]]></a>">>,
     ?assertEqual(iolist_size(exml:to_binary(parse(Raw))), exml:xml_size(parse(Raw))).
 
+sort_xmlel_identity_test() ->
+    El = #xmlel{
+            name = <<"foo">>,
+            attrs = [{<<"attr1">>, <<"bar">>}],
+            children = [#xmlcdata{ content = <<"some value">> }]
+           },
+    ?assertEqual(El, exml:xml_sort(El)).
+
+sort_xmlel_test() ->
+    Attrs = [{<<"attr1">>, <<"bar">>}, {<<"attr2">>, <<"baz">>}],
+    El1 = #xmlel{
+            name = <<"foo">>,
+            attrs = Attrs,
+            children = [#xmlcdata{ content = <<"some value">> }]
+           },
+    El2 = El1#xmlel{ attrs = lists:reverse(Attrs) },
+    ?assertNotEqual(El1, El2),
+    ?assertEqual(exml:xml_sort(El1), exml:xml_sort(El2)).
+
+sort_xmlel_nested_test() ->
+    Attrs = [{<<"attr1">>, <<"bar">>}, {<<"attr2">>, <<"baz">>}],
+    CData = [#xmlcdata{ content = <<"some value">> }],
+    Nested1 = #xmlel{
+                 name = <<"n1">>,
+                 attrs = Attrs,
+                 children = CData
+                },
+    Nested2 = #xmlel{
+                 name = <<"n2">>,
+                 attrs = lists:reverse(Attrs),
+                 children = CData
+                },
+    Children = [Nested1, Nested2],
+    El1 = #xmlel{
+             name = <<"foo">>,
+             children = Children
+            },
+    El2 = El1#xmlel{ children = lists:reverse(Children) },
+    ?assertNotEqual(El1, El2),
+    %% children order matters
+    ?assertNotEqual(exml:xml_sort(El1), exml:xml_sort(El2)).
+
+sort_xmlstreamstart_test() ->
+    Attrs = [{<<"attr1">>, <<"bar">>}, {<<"attr2">>, <<"baz">>}],
+    SS1 = #xmlstreamstart{name = <<"n1">>, attrs = Attrs},
+    SS2 = SS1#xmlstreamstart{attrs = lists:reverse(Attrs)},
+    ?assertNotEqual(SS1, SS2),
+    ?assertEqual(exml:xml_sort(SS1), exml:xml_sort(SS2)).
+
+sort_xmlstreamend_test() ->
+    SE1 = #xmlstreamend{name = <<"n1">>},
+    SE2 = SE1,
+    ?assertEqual(SE1, SE2),
+    ?assertEqual(exml:xml_sort(SE1), exml:xml_sort(SE2)).
+
+sort_xmlel_list_test() ->
+    El1 = #xmlel{
+            name = <<"foo">>,
+            attrs = [{<<"attr1">>, <<"bar">>}],
+            children = [#xmlcdata{ content = <<"some value">> }]
+           },
+    El2 = El1#xmlel{ name = <<"baz">> },
+    L1 = [El1, El2],
+    L2 = lists:reverse(L1),
+    ?assertNotEqual(L1, L2),
+    ?assertEqual(exml:xml_sort(L1), exml:xml_sort(L2)).
+
+assert_xmlel_equal_macro_positive_test() ->
+    Attrs = [{<<"attr1">>, <<"bar">>}, {<<"attr2">>, <<"baz">>}],
+    El1 = #xmlel{
+             name = <<"foo">>,
+             attrs = Attrs,
+             children = [#xmlcdata{ content = <<"some value">> }]
+            },
+    El2 = El1#xmlel{ attrs = lists:reverse(Attrs) },
+    ?assertEqual(ok, ?exmlAssertEqual(El1, El2)).
+
+assert_xmlel_equal_macro_negative_test() ->
+    El1 = #xmlel{
+             name = <<"foo">>,
+             attrs = [{<<"attr1">>, <<"bar">>}, {<<"attr2">>, <<"baz">>}],
+             children = [#xmlcdata{ content = <<"some value">> }]
+            },
+    El2 = El1#xmlel{ attrs = [] },
+    ?assertError({exmlAssertEqual, [_, _, _, {expected, El1}, {value, El2}]},
+                 ?exmlAssertEqual(El1, El2)).
+
 throws_error_when_record_is_invalid_test() ->
     BadExml = #xmlel{name = <<"pp">>, attrs = 1},
     ?assertError({badxml, BadExml, _}, exml:to_binary(BadExml)).


### PR DESCRIPTION
The assertion is meant to be used in tests.

It's still lacking:
* [x] better documentation (for functions; in README)
* [x] appropriate tests
