### PR TITLE
add ref field to xmlel, so that we can compare elements for identity

### DIFF
--- a/include/exml.hrl
+++ b/include/exml.hrl
@@ -4,6 +4,7 @@
 -record(xmlcdata, {content = [] :: iodata()}).
 
 -record(xmlel, {name :: binary(),
+                ref :: reference() | undefined,
                 attrs = [] :: [exml:attr()],
                 children =  [] :: [exml:element() | exml:cdata()]}).
 


### PR DESCRIPTION
A new record field, by default does nothing. If we need to check whether two stanzas are effectively the same stanza or not we can add a reference here.