### PR TITLE
Handle to_binary-ing arbitrary lists of stream elements.

### DIFF
--- a/src/exml_nif.erl
+++ b/src/exml_nif.erl
@@ -13,7 +13,7 @@
 
 -export([create/2, parse/1, parse_next/2, escape_cdata/1,
          to_binary/2, reset_parser/1]).
--export_type([parser/0]).
+-export_type([parser/0, stream_element/0]).
 
 -on_load(load/0).
 

--- a/src/exml_stream.erl
+++ b/src/exml_stream.erl
@@ -17,6 +17,8 @@
          free_parser/1]).
 
 -export_type([element/0,
+              start/0,
+              stop/0,
               parser/0,
               parser_opt/0]).
 
@@ -25,6 +27,8 @@
                  buffer :: [binary()]
                 }).
 
+-type start() :: #xmlstreamstart{}.
+-type stop() :: #xmlstreamend{}.
 -type element() :: exml_nif:stream_element().
 -type parser() :: #parser{}.
 %% infinite_stream - no distinct "stream start" or "stream end", only #xmlel{} will be returned

--- a/test/exml_tests.erl
+++ b/test/exml_tests.erl
@@ -11,6 +11,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("exml/include/exml.hrl").
+-include_lib("exml/include/exml_stream.hrl").
 
 -compile(export_all).
 
@@ -34,6 +35,12 @@ size_of_exml_with_cdata_test() ->
 throws_error_when_record_is_invalid_test() ->
     BadExml = #xmlel{name = <<"pp">>, attrs = 1},
     ?assertError({badxml, BadExml, _}, exml:to_binary(BadExml)).
+
+to_binary_arbitrary_stream_elements_test() ->
+    Elements = [#xmlcdata{content = <<"content">>},
+                #xmlstreamend{name = <<"endname">>},
+                #xmlstreamstart{name = <<"name">>, attrs = [{<<"a">>, <<"b">>}]}],
+    ?assertEqual(<<"content</endname><name a='b'>">>, exml:to_binary(Elements)).
 
 parse(Doc) ->
     case exml:parse(Doc) of


### PR DESCRIPTION
Many of our tests in other projects create arbitrary chains of elements, or incomplete XML streams - add functions to restore that ability of exml.