### PR TITLE
Add stdlib into LDFLAGS

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,8 @@
         ["c_src/*.cpp"],
 
         % Using options
-        [ {env, [{ "CXXFLAGS", "$CXXFLAGS -std=c++11" }]} ]
+        [ {env, [{ "CXXFLAGS", "$CXXFLAGS -std=c++11" },
+                 { "LDFLAGS", "$LDFLAGS -lstdc++" }]} ]
      }
  ]}.
 


### PR DESCRIPTION
Escalus uses rebar 2.2.0 for compiling tests.
I am getting `undefined symbol: _ZNKSt13runtime_error4whatEv'` error, when trying to load library.

Apparently, very old versions of rebar 2 always use cc to link libraries. But we need c++ (g++) to link the library. Or we can add `-lstdc++` as a workaround.

https://github.com/rebar/rebar/pull/617

This change is not needed for rebar 2.6.3 or rebar 3.

I've tested it, it compiles exml for escalus on travis with this PR.


Update: re2 also encouraged the issue. More advanced solution https://github.com/tuncer/re2/blob/v1.7.5/rebar.config.script#L69
Apparently, this code is missing in the most recent version of re2 rebar.config.

So, I am thinking that we can deprecate rebar 2.6.3 and below, as an alternative.
And start using rebar 3 or rebar 2.6.4, that chooses a proper linker.
