### PR TITLE
OTP23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,29 @@
 language: erlang
+
 branches:
-        only:
-                - master
+    only:
+        - master
+
 notifications:
-        email: mongoose-im@erlang-solutions.com
+    email: mongoose-im@erlang-solutions.com
+
 otp_release:
-        - 19.3
-        - 20.3
-        - 21.0
-        - 22.0
+    - 19.3
+    - 20.3
+    - 21.3
+    - 22.3
+    - 23.0
+
 install:
-        - make
-        - make test-compile
-        - travis_retry pip install --user codecov
+    - make
+    - make test-compile
+    - travis_retry pip install --user codecov
+
 script:
-        - make test
-        - make dialyzer
+    - make test
+    - make dialyzer
 
 after_success:
-        - make coverage-report
-        - make codecov
-        - codecov
+    - make coverage-report
+    - make codecov
+    - codecov

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ codecov: _build/test/cover/eunit.coverdata
 	./rebar3 as test codecov analyze
 
 rebar3:
-	wget https://github.com/erlang/rebar3/releases/download/3.6.1/rebar3 &&\
+	wget https://github.com/erlang/rebar3/releases/download/3.13.2/rebar3 &&\
 	chmod u+x rebar3
 
 dialyzer: rebar3

--- a/rebar.config
+++ b/rebar.config
@@ -7,10 +7,7 @@
          [
             pc,
             coveralls,
-            {rebar3_codecov,
-                {git,
-                    "https://github.com/zofpolkowska/rebar3_codecov.git",
-                    {ref, "3d0af19"}}}
+            {rebar3_codecov, {git, "https://github.com/esl/rebar3_codecov.git", {ref, "6bd31cc"}}}
          ]}
      ]}
  ]}.


### PR DESCRIPTION
rebar3_codecov dependency needed to be updated, as it uses jiffy.

Some indentation was also improved in the .travis.yml file.