### PR TITLE
Fix bug for subelement_with_name_and_ns

### DIFF
--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -185,7 +185,9 @@ subelement_with_name_and_ns(Element, Name, NS, Default) ->
     case subelement(Element, Name, undefined) of
         undefined ->
             Default;
-        SubElement ->
+        #xmlcdata{} ->
+            Default;
+        #xmlel{} = SubElement ->
             subelement_or_default(SubElement, NS, Default)
     end.
 

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -213,6 +213,10 @@ path_query_test() ->
                  exml_query:path(?MY_SPOON, [{element_with_ns, <<"urn:accidents">>},
                                              {attr, <<"no">>}])),
 
+    Msg = #xmlel{name = <<"message">>, children = [#xmlcdata{content = <<"x">>}]},
+    ?assertEqual(undefined,
+                 exml_query:path(Msg, [{element_with_ns, <<"x">>, <<"urn:wrong_ns">>}])),
+
     %% I couldn't find anything complex enough in that silly cartoon :[
     Qux = xml(<<"<foo><bar><baz a='b'>qux</baz></bar></foo>">>),
     ?assertEqual(<<"qux">>, exml_query:path(Qux, [{element, <<"bar">>},


### PR DESCRIPTION
subelement can also return xmlcdata elements, for which the attr
function will fail with a function_clause.