### PR TITLE
Cdata sections

### DIFF
--- a/src/exml.erl
+++ b/src/exml.erl
@@ -16,6 +16,7 @@
 -export([to_list/1,
          to_binary/1,
          to_iolist/1,
+         to_iolist/3,
          xml_size/1,
          xml_sort/1,
          to_pretty_iolist/1]).

--- a/src/exml.erl
+++ b/src/exml.erl
@@ -90,19 +90,20 @@ to_list(Element) ->
 to_binary(Element) ->
     iolist_to_binary(to_iolist(Element, not_pretty, node_data)).
 
--spec to_iolist(element() | [exml_stream:element()]) -> binary().
+-spec to_iolist(element() | [exml_stream:element()]) -> iodata().
 to_iolist(Element) ->
-    iolist_to_binary(to_iolist(Element, not_pretty, node_data)).
+    to_iolist(Element, not_pretty, node_data).
 
--spec to_pretty_iolist(element() | [exml_stream:element()]) -> binary().
+-spec to_pretty_iolist(element() | [exml_stream:element()]) -> iodata().
 to_pretty_iolist(Element) ->
-    iolist_to_binary(to_iolist(Element, pretty, node_data)).
+    to_iolist(Element, pretty, node_data).
 
 -spec parse(binary() | [binary()]) -> {ok, exml:element()} | {error, any()}.
 parse(XML) ->
     exml_nif:parse(XML).
 
--spec to_iolist(element() | [exml_stream:element()], prettify(), cdata_escape()) -> iolist().
+-spec to_iolist(exml_stream:element() | [exml_stream:element()], prettify(), cdata_escape()) ->
+    iodata().
 to_iolist(#xmlel{} = Element, Pretty, CDataEscape) ->
     to_binary_nif(Element, Pretty, CDataEscape);
 to_iolist([Element], Pretty, CDataEscape) ->
@@ -118,8 +119,8 @@ to_iolist([Head | _] = Elements, Pretty, CDataEscape) ->
         _ ->
             [to_iolist(El, Pretty, CDataEscape) || El <- Elements]
     end;
-to_iolist(#xmlstreamstart{name = Name, attrs = Attrs}, _Pretty, CDataEscape) ->
-    Result = to_binary_nif(#xmlel{name = Name, attrs = Attrs}, not_pretty, CDataEscape),
+to_iolist(#xmlstreamstart{name = Name, attrs = Attrs}, _Pretty, _CDataEscape) ->
+    Result = to_binary_nif(#xmlel{name = Name, attrs = Attrs}, not_pretty, node_data),
     FrontSize = byte_size(Result) - 2,
     <<Front:FrontSize/binary, "/>">> = Result,
     [Front, $>];

--- a/src/exml.erl
+++ b/src/exml.erl
@@ -83,18 +83,22 @@ xml_sort(#xmlstreamend{} = StreamEnd) ->
 xml_sort(Elements) when is_list(Elements) ->
     lists:sort([ xml_sort(E) || E <- Elements ]).
 
+%% @equiv erlang:binary_to_list(to_binary(Element))
 -spec to_list(element() | [exml_stream:element()]) -> string().
 to_list(Element) ->
     binary_to_list(to_binary(Element)).
 
+%% @equiv erlang:iolist_to_binary(to_iolist(Element, pretty, node_data))
 -spec to_binary(element() | [exml_stream:element()]) -> binary().
 to_binary(Element) ->
     iolist_to_binary(to_iolist(Element, not_pretty, node_data)).
 
+%% @equiv to_iolist(Element, not_pretty, node_data)
 -spec to_iolist(element() | [exml_stream:element()]) -> iodata().
 to_iolist(Element) ->
     to_iolist(Element, not_pretty, node_data).
 
+%% @equiv to_iolist(Element, pretty, node_data)
 -spec to_pretty_iolist(element() | [exml_stream:element()]) -> iodata().
 to_pretty_iolist(Element) ->
     to_iolist(Element, pretty, node_data).
@@ -103,6 +107,14 @@ to_pretty_iolist(Element) ->
 parse(XML) ->
     exml_nif:parse(XML).
 
+%% @doc Turn a –list of– exml element into iodata for IO interactions.
+%%
+%% The `Pretty' argument indicates if the generated XML should have new lines and indentation,
+%% which is useful for the debugging eye, or should rather be a minified version,
+%% which is better for IO.
+%%
+%% The `CDataEscape' argument indicates how to escape contents in the XML payload, as regular data
+%% that would escape character by character, or using a `<![CDATA[]]>' section.
 -spec to_iolist(exml_stream:element() | [exml_stream:element()], prettify(), cdata_escape()) ->
     iodata().
 to_iolist(#xmlel{} = Element, Pretty, CDataEscape) ->

--- a/src/exml_nif.erl
+++ b/src/exml_nif.erl
@@ -5,14 +5,11 @@
 
 -module(exml_nif).
 
--include("exml.hrl").
--include("exml_stream.hrl").
-
 -type parser() :: term().
 -type stream_element() :: exml:element() | exml_stream:start() | exml_stream:stop().
 
--export([create/2, parse/1, parse_next/2, escape_cdata/1,
-         to_binary/2, reset_parser/1]).
+-export([create/2, parse/1, parse_next/2, escape_cdata/2,
+         to_binary/3, reset_parser/1]).
 -export_type([parser/0, stream_element/0]).
 
 -on_load(load/0).
@@ -39,12 +36,12 @@ load() ->
 create(_, _) ->
     erlang:nif_error(not_loaded).
 
--spec escape_cdata(Bin :: iodata()) -> binary().
-escape_cdata(_Bin) ->
+-spec escape_cdata(Bin :: iodata(), exml:cdata_escape()) -> binary().
+escape_cdata(_Bin, _Opt) ->
      erlang:nif_error(not_loaded).
 
--spec to_binary(Elem :: exml:element(), pretty | not_pretty) -> binary().
-to_binary(_Elem, _Pretty) ->
+-spec to_binary(Elem :: exml:element(), exml:prettify(), exml:cdata_escape()) -> binary().
+to_binary(_Elem, _Pretty, _CData) ->
     erlang:nif_error(not_loaded).
 
 -spec parse(Bin :: binary() | [binary()]) -> {ok, exml:element()} | {error, Reason :: any()}.

--- a/test/exml_tests.erl
+++ b/test/exml_tests.erl
@@ -27,6 +27,11 @@ size_of_escaped_characters_test() ->
     Raw = <<"<a>&amp;</a>">>,
     ?assertEqual(iolist_size(Raw), exml:xml_size(parse(Raw))).
 
+to_binary_with_cdata_test() ->
+    Raw = <<"<a><![CDATA[ Within this Character Data block I can ",
+            "use double dashes as much as I want (along with <, &, ', and \")]]></a>">>,
+    ?assertEqual(Raw, exml:to_iolist(parse(Raw), not_pretty, node_cdata)).
+
 size_of_exml_with_cdata_test() ->
     Raw = <<"<a><![CDATA[ Within this Character Data block I can
             use double dashes as much as I want (along with <, &, ', and \")]]></a>">>,


### PR DESCRIPTION
It can happen that some subelement can contain a payload with for example, a big json object. The xml element could be use as an envelope for routing other abstract payloads, and so escaping them could make the blob much bigger for the network transfer, and very unreadable for the debugging eye. So at least make it optional that you want to use cdata escaping when needed.

There's also a couple of "breaking" changes, current code was doing `iolist_to_binary` for the function called `to_iolist`, which seems dummy, you might as well call `to_binary` if you want a binary. iodata usually has a performance advantage improvement for network transmission, so keep iodata as iodata when you want it.