### PR TITLE
Xml compliance against control characters

### DIFF
--- a/c_src/exml.cpp
+++ b/c_src/exml.cpp
@@ -125,7 +125,7 @@ namespace {
 ErlNifResourceType *parser_type;
 
 constexpr int default_parse_flags() {
-  return rapidxml::parse_no_string_terminators;
+  return rapidxml::parse_no_string_terminators | rapidxml::parse_validate_control_chars;
 }
 
 constexpr int parse_one() {

--- a/test/exml_properties_tests.erl
+++ b/test/exml_properties_tests.erl
@@ -10,6 +10,20 @@ p(Name, Property) ->
               (proper:conjunction([{Name, Property}]),
                [100, long_result, {to_file, user}])).
 
+vector_1_forbidden_control_char_test() ->
+    ?assertMatch({error, _}, exml:parse(<<"<body>", 16#1B,"</body>">>)).
+
+vector_2_forbidden_control_char_test() ->
+    ?assertMatch({error, _}, exml:parse(<<"<body", 16#1B,"></body", 16#1B,">">>)).
+
+vector_3_forbidden_control_char_test() ->
+    ?assertMatch({error, _}, exml:parse(<<"<body lang='en' bad='", 16#1B, "'></body>">>)).
+
+fail_forbidden_control_char_test() ->
+    p("All valid xml cdata can be parsed",
+      ?FORALL(Doc, utf8_doc_bad(),
+              not is_parseable(Doc))).
+
 parse_test() ->
     p("All valid xml cdata can be parsed",
       ?FORALL(Doc, utf8_doc(),
@@ -49,19 +63,31 @@ parse(Doc) ->
 utf8_doc() ->
     ?LET({{ElOpen,ElClose}, Cdata},
          {xml_open_close(), xml_cdata()},
-         unicode:characters_to_binary
-           (ElOpen ++ Cdata ++ ElClose)).
+         unicode:characters_to_binary(ElOpen ++ Cdata ++ ElClose)).
+
+utf8_doc_bad() ->
+    ?LET({{ElOpen,ElClose}, Cdata},
+         {xml_open_close_maybe_bad(), utf8_text_bad()},
+         unicode:characters_to_binary(ElOpen ++ Cdata ++ ElClose)).
 
 xml_open_close() ->
     ?LET(TagName, tagname_text(),
          {lists:flatten("<" ++ TagName ++ ">"),
           lists:flatten("</" ++ TagName ++ ">")}).
 
+xml_open_close_maybe_bad() ->
+    ?LET(TagName, tagname_text_maybe_bad(),
+         {lists:flatten("<" ++ TagName ++ ">"),
+          lists:flatten("</" ++ TagName ++ ">")}).
+
 tagname_text() ->
     non_empty(list(choose($a, $z))).
 
+tagname_text_maybe_bad() ->
+    non_empty(list(oneof([$a, $z, xml_c0_forbidden_control()]))).
+
+%% see: https://en.wikipedia.org/wiki/Valid_characters_in_XML#XML_1.0
 utf8_char() ->
-    %% see: https://en.wikipedia.org/wiki/Valid_characters_in_XML#XML_1.0
     oneof([xml_escaped_entity(),
            xml_c0_control(),
            xml_utf8_bmp_char()]).
@@ -69,13 +95,23 @@ utf8_char() ->
 xml_c0_control() ->
     elements([16#0009, 16#000A, 16#000D]).
 
+xml_c0_forbidden_control() ->
+    elements([16#0000, 16#0001, 16#0002, 16#0003, 16#0004, 16#0005, 16#0006, 16#0007,
+              16#0008,                   16#000B, 16#000C,          16#000E, 16#000F,
+              16#0010, 16#0011, 16#0012, 16#0013, 16#0014, 16#0015, 16#0016, 16#0017,
+              16#0018, 16#0019, 16#001A, 16#001B, 16#001C, 16#001D, 16#001E, 16#001F]).
+
+utf8_text_bad() ->
+    non_empty(list(xml_c0_forbidden_control())).
+
 xml_utf8_bmp_char() ->
     ?SUCHTHAT(C, oneof([choose(16#0020,16#D7FF),
-                   choose(16#E000, 16#FFFD)]),
+                        choose(16#E000, 16#FFFD)]),
               not lists:member(C, [$<,$>,$&])).
 
 xml_escaped_entity() ->
     oneof(["&amp;", "&lt;", "&gt;"]).
+
 utf8_text() ->
     non_empty(list(utf8_char())).
 


### PR DESCRIPTION
I checked all the pertaining RFCs, and not only [XMPP states being defined for XML 1.0 fifth edition](https://datatracker.ietf.org/doc/html/rfc6120#ref-XML), but also both [XML 1.0](https://www.w3.org/TR/2008/REC-xml-20081126/#charsets) or [XML 1.1](https://www.w3.org/TR/2006/REC-xml11-20060816/#charsets) wouldn’t allow such character on the body (1.1, which is barely used anyway, allows such characters in very special places, but the cdata is not one of them).

Also indeed, I can confirm that our XML parser accepts the escape char inside the body, in the screenshot below we can see that a body with just a space is quickly stripped, but the one with the escape character keeps the \e code in the xml cdata section:
![image](https://user-images.githubusercontent.com/27267603/170363313-ec50be68-ad1a-4705-ba12-6e01b0ac2129.png)

Not only that, but the XML specification says that only the following chars are allowed:

    Char	   ::=   	#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]

and then I can confirm that the xml parser also accepts 0x1c, 0x1d, etc.

---

The fix is to now, on every character being processed, check if such character is any of the disallowed ones. A few tests are added. This unfortunately has an impact on performance, with an average worsening of around I guess 10-15%

<details>
  <summary>benchmarks</summary>

I have the xml payloads from this test generated in my computer, feel free to ask to share them
```
##### With input 1 #####
Name                ips        average  deviation         median         99th %
master         398.65 K        2.51 μs  ±3113.73%        1.07 μs        2.69 μs
this brch      366.11 K        2.73 μs  ±2870.52%        1.25 μs        2.83 μs

##### With input 2 #####
Name                ips        average  deviation         median         99th %
master         318.30 K        3.14 μs  ±2568.48%        1.33 μs        3.04 μs
this brch      305.15 K        3.28 μs  ±2411.22%        1.47 μs        3.18 μs

##### With input 3 #####
Name                ips        average  deviation         median         99th %
master           6.85 K      145.91 μs    ±54.58%      116.55 μs      424.71 μs
this brch        6.41 K      156.03 μs    ±51.03%      127.66 μs      472.68 μs

##### With input 4 #####
Name                ips        average  deviation         median         99th %
master           5.87 K      170.41 μs    ±51.77%      130.51 μs      516.84 μs
this brch        5.43 K      184.22 μs    ±46.77%      144.83 μs      531.45 μs

##### With input 5 #####
Name                ips        average  deviation         median         99th %
master         844.20 K        1.18 μs  ±6480.92%        0.47 μs        1.60 μs
this brch      825.42 K        1.21 μs  ±6204.77%        0.51 μs        1.50 μs

##### With input big big test #####
Name                ips        average  deviation         median         99th %
master            29.49       33.91 ms    ±33.59%       42.60 ms       50.83 ms
this brch         27.65       36.17 ms    ±32.21%       38.00 ms       63.03 ms

##### With input generated #####
Name                ips        average  deviation         median         99th %
master          77.78 K       12.86 μs   ±614.82%        6.36 μs       38.81 μs
this brch       76.87 K       13.01 μs   ±588.76%        6.68 μs       37.31 μs

##### With input generated-oracle #####
Name                ips        average  deviation         median         99th %
master         102.55 K        9.75 μs   ±878.33%        4.47 μs       18.48 μs
this brch      101.30 K        9.87 μs   ±840.00%        4.52 μs       20.40 μs

##### With input mystic-library #####
Name                ips        average  deviation         median         99th %
master           192.34        5.20 ms    ±30.87%        4.51 ms        7.94 ms
this brch        183.72        5.44 ms    ±29.26%        4.73 ms        8.25 ms
```
</details>


A possible solution would be to make it configurable, so that the control char validation could be given as a flag to the erlang call. But on the C level that would probably make the code size grow considerably, as part of the optimisations in rapidxml is the auto-generated code for each branch, instead of one code with many branching conditionals.