### PR TITLE
Throw exception on null characters

### DIFF
--- a/c_src/exml.cpp
+++ b/c_src/exml.cpp
@@ -11,8 +11,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstring>
 #include <iostream>
-#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -481,24 +481,19 @@ static ERL_NIF_TERM parse_next(ErlNifEnv *env, int argc,
   if (!parser->copy_buffer(env, argv[1]))
     return enif_make_badarg(env);
 
-  // Skip initial whitespace even if we don't manage to parse anything.
-  // Also needed for has_stream_closing_tag to recognize the tag.
   // Raise an exception when null character is found.
-
-  std::size_t offset = 0;
-  bool offset_set = false;
-
-  for (std::size_t i = 0; i < Parser::buffer.size() - 1; i++) {
-    unsigned char byte = Parser::buffer[i];
-    if (byte == 0) {
-      return enif_make_tuple2(
+  const char *data = reinterpret_cast<const char*>(&Parser::buffer[0]);
+  if (std::strlen(data) != Parser::buffer.size() - 1)
+    return enif_make_tuple2(
         env, atom_error,
         enif_make_string(env, "null character found in buffer", ERL_NIF_LATIN1));
-    } else if (!std::isspace(byte) && !offset_set) {
-      offset = i;
-      offset_set = true;
-    }
-  }
+
+  // Skip initial whitespace even if we don't manage to parse anything.
+  // Also needed for has_stream_closing_tag to recognize the tag.
+  std::size_t offset = 0;
+  while (offset < Parser::buffer.size() - 1 &&
+         std::isspace(Parser::buffer[offset]))
+    ++offset;
 
   ParseCtx ctx{env, parser};
   xml_document::ParseResult result;

--- a/test/exml_stream_tests.erl
+++ b/test/exml_stream_tests.erl
@@ -191,18 +191,24 @@ stream_max_child_size_test() ->
 
 infinite_stream_partial_chunk_test() ->
     {ok, Parser0} = exml_stream:new_parser([{infinite_stream, true}, {autoreset, true}]),
-	{ok, Parser1, Open} = exml_stream:parse(Parser0, <<"<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='i.am.banana.com' version='1.0'/>">>),
+    {ok, Parser1, Open} = exml_stream:parse(Parser0, <<"<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='i.am.banana.com' version='1.0'/>">>),
     ?assertEqual(
        [#xmlel{name = <<"open">>,
-			   attrs = [{<<"xmlns">>, <<"urn:ietf:params:xml:ns:xmpp-framing">>},
-						{<<"to">>, <<"i.am.banana.com">>},
-						{<<"version">>, <<"1.0">>}]}],
+               attrs = [{<<"xmlns">>, <<"urn:ietf:params:xml:ns:xmpp-framing">>},
+                        {<<"to">>, <<"i.am.banana.com">>},
+                        {<<"version">>, <<"1.0">>}]}],
        Open),
     {ok, Parser2, A} = exml_stream:parse(Parser1, <<"<a></a>">>),
-	?assertEqual([#xmlel{name = <<"a">>, attrs = []}], A),
-	{ok, Parser3, Empty0} = exml_stream:parse(Parser2, <<" ">>),
-	?assertEqual([], Empty0),
-	{ok, Parser4, Empty1} = exml_stream:parse(Parser3, <<"<b></b">>),
-	?assertEqual([], Empty1),
-	{ok, _Parser5, B} = exml_stream:parse(Parser4, <<">">>),
-	?assertEqual([#xmlel{name = <<"b">>, attrs = []}], B).
+    ?assertEqual([#xmlel{name = <<"a">>, attrs = []}], A),
+    {ok, Parser3, Empty0} = exml_stream:parse(Parser2, <<" ">>),
+    ?assertEqual([], Empty0),
+    {ok, Parser4, Empty1} = exml_stream:parse(Parser3, <<"<b></b">>),
+    ?assertEqual([], Empty1),
+    {ok, _Parser5, B} = exml_stream:parse(Parser4, <<">">>),
+    ?assertEqual([#xmlel{name = <<"b">>, attrs = []}], B).
+
+null_character_test() ->
+    {ok, P1} = exml_stream:new_parser(),
+    ?assertMatch({error, _}, exml_stream:parse(P1, <<"\0<stream>">>)),
+    {ok, P2} = exml_stream:new_parser(),
+    ?assertMatch({error, _}, exml_stream:parse(P2, <<"<stream>\0">>)).


### PR DESCRIPTION
`exml_stream` doesn't validate null characters correctly. Here is an example:

```erl
> {ok, Parser} = exml_stream:new_parser(),
> exml_stream:parse(Parser, <<"\0<xml>">>).
{ok,{parser,#Ref<0.816531939.1357774849.238018>,
            [<<0,60,120,109,108,62>>]},
    []}
```

Any further data passed via `exml_stream:parse/2` to the parser won't be processed as well because rapidxml works on null-terminated strings and treats the whole input as empty. The similar issue happens when null character is in the middle of input (other exception is thrown but it has `eof` flag as well).

I implemented the fix that checks (in advance) whether the buffer contains null character. If so, it throws the error immediately. This way we can make sure that input received from Erlang will be valid in term of processing.

