### PR TITLE
Fix subelement_with_name_and_ns bug #38

### DIFF
--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -182,21 +182,11 @@ subelement_with_name_and_ns(Element, Name, NS) ->
 -spec subelement_with_name_and_ns(exml:element(), binary(), binary(), Other) ->
     exml:element() | Other.
 subelement_with_name_and_ns(Element, Name, NS, Default) ->
-    case subelement(Element, Name, undefined) of
-        undefined ->
+    case subelements_with_name_and_ns(Element, Name, NS) of
+        [] ->
             Default;
-        #xmlcdata{} ->
-            Default;
-        #xmlel{} = SubElement ->
-            subelement_or_default(SubElement, NS, Default)
-    end.
-
-subelement_or_default(SubElement, NS, Default) ->
-    case attr(SubElement, <<"xmlns">>) of
-        NS ->
-            SubElement;
-        _ ->
-            Default
+        [FirstElem | _] ->
+            FirstElem
     end.
 
 -spec subelements(exml:element(), binary()) -> [exml:element()].

--- a/test/exml_query_tests.erl
+++ b/test/exml_query_tests.erl
@@ -10,7 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("exml.hrl").
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -define(MY_SPOON, xml(<<"<spoon whose='my'>",
                           "<problem no='1' xmlns='urn:issues'>is too big</problem>",
@@ -130,6 +130,13 @@ element_with_name_and_ns_query_test() ->
     ?assertEqual(ValidResult, exml_query:path(chat_markers(),
                                               [{element_with_ns, <<"displayed">>,
                                                <<"urn:xmpp:chat-markers:0">>}])).
+
+element_with_name_and_ns_two_names_only_one_ns_query_test() ->
+    Elem1 = #xmlel{name = <<"a">>, attrs = [{<<"xmlns">>, <<"ns1">>}]},
+    Elem2 = #xmlel{name = <<"a">>, attrs = [{<<"xmlns">>, <<"ns2">>}]},
+    Xml = #xmlel{name = <<"element">>, children = [Elem1, Elem2]},
+    ?assertEqual(Elem2, exml_query:subelement_with_name_and_ns(Xml, <<"a">>, <<"ns2">>)),
+    ?assertEqual(Elem2, exml_query:path(Xml, [{element_with_ns, <<"a">>, <<"ns2">>}])).
 
 no_element_with_name_and_ns_query_test() ->
     ?assertEqual(none,


### PR DESCRIPTION
If we have list of elements:
- [#xmlel{name = <<"a">>, attrs = [{<<"xmlns">>, <<"ns">>}]}, #xmlel{name = <<"a">>, attrs = [{<<"xmlns">>, <<"ns2">>}]}] and call exml_query:subelement_with_name_and_ns/3 with <<"a">> and <<"ns2">>, we will get:
- currently - undefined
- expected - #xmlel{name = <<"a">>, attrs = [{<<"xmlns">>, <<"ns2">>}]}]}

Fixes #38 