### PR TITLE
Fix and improve the check for maximum element size

### DIFF
--- a/src/exml_stream.erl
+++ b/src/exml_stream.erl
@@ -29,11 +29,11 @@
 -type stop() :: #xmlstreamend{}.
 -type element() :: exml_nif:stream_element().
 -type parser() :: #parser{}.
-%% infinite_stream - no distinct "stream start" or "stream end", only #xmlel{} will be returned
-%% max_child_size - specifies maximum byte size of any child of the root element. The byte size is
-%%                  counted from the start tag until the opening character of its end tag. Disabled
-%%                  if set to 0 (default).
--type parser_opt() :: {infinite_stream, boolean()} | {max_child_size, non_neg_integer()}.
+%% infinite_stream - No distinct "stream start" or "stream end", only #xmlel{} will be returned.
+%% max_element_size - Specifies maximum byte size of any parsed XML element.
+%%                    The only exception is the "stream start" element,
+%%                    for which only the size of the opening tag is limited.
+-type parser_opt() :: {infinite_stream, boolean()} | {max_element_size, non_neg_integer()}.
 
 %%%===================================================================
 %%% Public API
@@ -45,9 +45,9 @@ new_parser() ->
 
 -spec new_parser([parser_opt()]) -> {ok, parser()} | {error, any()}.
 new_parser(Opts)->
-    MaxChildSize = proplists:get_value(max_child_size, Opts, 0),
+    MaxElementSize = proplists:get_value(max_element_size, Opts, 0),
     InfiniteStream = proplists:get_value(infinite_stream, Opts, false),
-    case exml_nif:create(MaxChildSize, InfiniteStream) of
+    case exml_nif:create(MaxElementSize, InfiniteStream) of
         {ok, EventParser} ->
             {ok, #parser{event_parser = EventParser, buffer = []}};
         Error ->

--- a/test/exml_stream_tests.erl
+++ b/test/exml_stream_tests.erl
@@ -160,7 +160,7 @@ conv_attr_test() ->
 -define(RESTART_TEST_STREAM, <<"<stream:stream xmlns:stream='something'><quote/><stream:stream xmlns:stream='else'><other/><things/>">>).
 
 stream_restarts_test() ->
-    {ok, Parser0} = exml_stream:new_parser([{start_tag, <<"stream:stream">>}]),
+    {ok, Parser0} = exml_stream:new_parser([]),
     {ok, _Parser1, Elements} = exml_stream:parse(Parser0, ?RESTART_TEST_STREAM),
     ?assertMatch(
         [#xmlstreamstart{name = <<"stream:stream">>},
@@ -174,7 +174,7 @@ stream_restarts_test() ->
                                       "<?xml version='1.0'?><stream:stream xmlns:stream='a'><other/>">>).
 
 stream_restarts_with_xml_declaration_test() ->
-    {ok, Parser0} = exml_stream:new_parser([{start_tag, <<"stream:stream">>}]),
+    {ok, Parser0} = exml_stream:new_parser([]),
     {ok, _Parser1, Elements} = exml_stream:parse(Parser0, ?RESTART_TEST_STREAM_XMLDEC),
     ?assertMatch(
         [#xmlstreamstart{name = <<"stream:stream">>},
@@ -229,7 +229,7 @@ stream_max_incomplete_root_element_size_test() ->
     ?assertEqual({error, "element too big"}, exml_stream:parse(Parser1, <<"<c>1234</c">>)).
 
 infinite_stream_partial_chunk_test() ->
-    {ok, Parser0} = exml_stream:new_parser([{infinite_stream, true}, {autoreset, true}]),
+    {ok, Parser0} = exml_stream:new_parser([{infinite_stream, true}]),
     {ok, Parser1, Open} = exml_stream:parse(Parser0, <<"<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='i.am.banana.com' version='1.0'/>">>),
     ?assertEqual(
        [#xmlel{name = <<"open">>,


### PR DESCRIPTION
The original option named `max_child_size` had two major issues:
1. It only checked incomplete (chunked) elements
2. It also checked the stream opening tag

They are both addressed:
1. Added a check for complete elements as well. The check prevents constructing the Erlang term.
2. Modified the option name to `max_element_size`. When `infinite_stream` is used, the elements are not children anyway. The size of the stream-opening tag is still checked, but it is documented now. One could (maliciously or not) send a huge stream-opening tag, so the check makes sense.

Other changes:
- Updated error messages.
- The check for incomplete elements was failing too soon - one more character should be accepted. Now at most `max_element-size - 1` characters are accepted, because we know that at least one more character will be parsed.
- Removed unused obsolete options from tests.

---
Recommended for the future: add OTP 26 to CI.