### PR TITLE
Enable eqwalizer

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,10 @@
-{deps, []}.
+{deps, [
+    {eqwalizer_support,
+     {git_subdir,
+      "https://github.com/whatsapp/eqwalizer.git",
+      {branch, "main"},
+      "eqwalizer_support"}}
+]}.
 
 {dialyzer,
  [{warnings,
@@ -25,7 +31,15 @@
     ]}
 ]}.
 
-{project_plugins, [rebar3_ex_doc]}.
+{project_plugins,
+ [
+  rebar3_ex_doc,
+  {eqwalizer_rebar3,
+   {git_subdir,
+    "https://github.com/whatsapp/eqwalizer.git",
+    {branch, "main"},
+    "eqwalizer_rebar3"}}
+ ]}.
 {plugins, [pc, rebar3_hex]}.
 
 % Interrupt compilation, if the artifact is not found

--- a/src/exml.app.src
+++ b/src/exml.app.src
@@ -4,7 +4,8 @@
   {registered, []},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    eqwalizer_support
    ]},
   {env, []},
   {modules, []},

--- a/src/exml.erl
+++ b/src/exml.erl
@@ -69,7 +69,6 @@ xml_size({Key, Value}) when is_binary(Key) ->
 %% https://github.com/erszcz/rxml/commit/e8483408663f0bc2af7896e786c1cdea2e86e43d
 -spec xml_sort([item()]) -> [item()];
               (element()) -> element();
-              (attr()) -> attr();
               (cdata()) -> cdata();
               (exml_stream:start()) -> exml_stream:start();
               (exml_stream:stop()) -> exml_stream:stop().

--- a/src/exml_nif.erl
+++ b/src/exml_nif.erl
@@ -25,9 +25,15 @@
 load() ->
     PrivDir = case code:priv_dir(?MODULE) of
                   {error, _} ->
-                      EbinDir = filename:dirname(code:which(?MODULE)),
-                      AppPath = filename:dirname(EbinDir),
-                      filename:join(AppPath, "priv");
+                      case code:which(?MODULE) of
+                          Path when is_list(Path) ->
+                              EbinDir = filename:dirname(Path),
+                              AppPath = filename:dirname(EbinDir),
+                              filename:join(AppPath, "priv");
+                          _ ->
+                              %% cover_compiled | preloaded | non_existing
+                              erlang:error({cannot_get_load_path, ?MODULE})
+                      end;
                   Path ->
                       Path
               end,

--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -74,7 +74,7 @@ path(Element, Path) ->
 %% '''
 %% will return `<<"Message from bob to alice">>'
 %% @end
--spec path(exml:element(), path(), Default) -> exml:element() | binary() | Default.
+-spec path(exml:element() | undefined, path(), Default) -> exml:element() | binary() | Default.
 path(#xmlel{} = Element, [], _) ->
     Element;
 path(#xmlel{} = Element, [{element, Name} | Rest], Default) ->

--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -129,10 +129,10 @@ subelement(Element, Name) ->
 -spec subelement(exml:element(), binary(), Default) -> exml:element() | Default.
 subelement(#xmlel{children = Children}, Name, Default) ->
     case lists:keyfind(Name, #xmlel.name, Children) of
+        #xmlel{} = Result ->
+            Result;
         false ->
-            Default;
-        Result ->
-            Result
+            Default
     end.
 
 %% @equiv path(Element, [{element_with_ns, NS}])

--- a/src/exml_query.erl
+++ b/src/exml_query.erl
@@ -161,7 +161,9 @@ child_with_ns([_ | Rest], NS, Default) ->
 -spec subelement_with_attr(exml:element(), AttrName :: binary(), AttrValue :: binary()) ->
     exml:element() | undefined.
 subelement_with_attr(Element, AttrName, AttrValue) ->
-    subelement_with_attr(Element, AttrName, AttrValue, undefined).
+    %% eqwalizer can't tell that Default in subelement_with_attr/4
+    %% in this case WILL be just 'undefined', which is a valid return type from this function.
+    eqwalizer:dynamic_cast(subelement_with_attr(Element, AttrName, AttrValue, undefined)).
 
 %% @equiv path(Element, [{element_with_attr, AttrName, AttrValue}], Default)
 -spec subelement_with_attr(Element, AttrName, AttrValue, Default) -> SubElement | Default when
@@ -209,7 +211,7 @@ subelements(#xmlel{children = Children}, Name) ->
                         true;
                     (_) ->
                         false
-                 end, Children).
+                 end, eqwalizer:dynamic_cast(Children)).
 
 %% @equiv paths(Element, [{element_with_ns, NS}])
 -spec subelements_with_ns(exml:element(), binary()) -> [exml:element()].
@@ -218,7 +220,7 @@ subelements_with_ns(#xmlel{children = Children}, NS) ->
                         NS =:= attr(Child, <<"xmlns">>);
                     (_) ->
                         false
-                 end, Children).
+                 end, eqwalizer:dynamic_cast(Children)).
 
 %% @equiv paths(Element, [{element_with_ns, Name, NS}])
 -spec subelements_with_name_and_ns(exml:element(), binary(), binary()) -> [exml:element()].
@@ -228,7 +230,7 @@ subelements_with_name_and_ns(#xmlel{children = Children}, Name, NS) ->
                          NS =:= attr(Child, <<"xmlns">>);
                     (_) ->
                         false
-                 end, Children).
+                 end, eqwalizer:dynamic_cast(Children)).
 
 %% @equiv paths(Element, [{element_with_attr, AttrName, AttrValue}])
 -spec subelements_with_attr(exml:element(), binary(), binary()) -> [exml:element()].
@@ -237,7 +239,7 @@ subelements_with_attr(#xmlel{children = Children}, AttrName, Value) ->
                         Value =:= attr(Child, AttrName);
                     (_) ->
                         false
-                 end, Children).
+                 end, eqwalizer:dynamic_cast(Children)).
 
 %% @equiv path(Element, [cdata])
 -spec cdata(exml:element()) -> binary().

--- a/test/exml_tests.erl
+++ b/test/exml_tests.erl
@@ -16,7 +16,7 @@
 -compile(export_all).
 
 application_test() ->
-    ?assertEqual(ok, application:start(exml)),
+    ?assertMatch({ok, _}, application:ensure_all_started(exml)),
     ?assertEqual(ok, application:stop(exml)).
 
 size_of_normal_xml_test() ->


### PR DESCRIPTION
This PR enables WhatsApp's eqWAlizer and fixes all errors it reports in exml. It's also intended as a tech spike to familiarise with eqwalizer and its capabilities.

All in all, the impression is very good - the typechecker is fast, reliable, easy to integrate with editor/IDE. Definitely recommended 👍

One shortcoming I found is that eqwalizer doesn't report redundant spec clauses. Dialyzer, however, seems to catch such cases if they're left after making a project eqwalizer clean, so the combo of both tools offers a comprehensive safety harness.

I'm creating this PR as a preview, not to force inclusion of eqwalizer in all our projects.