### PR TITLE
Add CDATA escaping to exml

### DIFF
--- a/c_src/exml.cpp
+++ b/c_src/exml.cpp
@@ -336,7 +336,7 @@ bool build_attrs(ErlNifEnv *env, xml_document &doc, ERL_NIF_TERM attrs,
 bool build_el(ErlNifEnv *env, xml_document &doc, const ERL_NIF_TERM elem[],
               rapidxml::xml_node<unsigned char> &node) {
   ErlNifBinary name;
-  if (!enif_inspect_iolist_as_binary(env, elem[1], &name))
+  if (!enif_inspect_binary(env, elem[1], &name))
     return false;
 
   auto child = doc.impl.allocate_node(rapidxml::node_element);

--- a/c_src/rapidxml_print.hpp
+++ b/c_src/rapidxml_print.hpp
@@ -151,7 +151,7 @@ namespace rapidxml
         {
             assert(node->type() == node_data);
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             out = copy_and_expand_chars(node->value(), node->value() + node->value_size(), Ch(0), out);
             return out;
         }
@@ -162,7 +162,7 @@ namespace rapidxml
         {
             assert(node->type() == node_cdata);
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             *out = Ch('<'); ++out;
             *out = Ch('!'); ++out;
             *out = Ch('['); ++out;
@@ -187,7 +187,7 @@ namespace rapidxml
 
             // Print element name and attributes, if any
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             *out = Ch('<'), ++out;
             out = copy_chars(node->name(), node->name() + node->name_size(), out);
             out = print_attributes(out, node, flags);
@@ -221,9 +221,9 @@ namespace rapidxml
                     // Print all children with full indenting
                     if (!(flags & print_no_indenting))
                         *out = Ch('\n'), ++out;
-                    out = print_children(out, node, flags, indent + 1);
+                    out = print_children(out, node, flags, indent + 2);
                     if (!(flags & print_no_indenting))
-                        out = fill_chars(out, indent, Ch('\t'));
+                        out = fill_chars(out, indent, Ch(' '));
                 }
 
                 // Print node end
@@ -241,7 +241,7 @@ namespace rapidxml
         {
             // Print declaration start
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             *out = Ch('<'), ++out;
             *out = Ch('?'), ++out;
             *out = Ch('x'), ++out;
@@ -264,7 +264,7 @@ namespace rapidxml
         {
             assert(node->type() == node_comment);
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             *out = Ch('<'), ++out;
             *out = Ch('!'), ++out;
             *out = Ch('-'), ++out;
@@ -282,7 +282,7 @@ namespace rapidxml
         {
             assert(node->type() == node_doctype);
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             *out = Ch('<'), ++out;
             *out = Ch('!'), ++out;
             *out = Ch('D'), ++out;
@@ -304,7 +304,7 @@ namespace rapidxml
         {
             assert(node->type() == node_pi);
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             *out = Ch('<'), ++out;
             *out = Ch('?'), ++out;
             out = copy_chars(node->name(), node->name() + node->name_size(), out);
@@ -321,7 +321,7 @@ namespace rapidxml
         {
             assert(node->type() == node_literal);
             if (!(flags & print_no_indenting))
-                out = fill_chars(out, indent, Ch('\t'));
+                out = fill_chars(out, indent, Ch(' '));
             out = copy_chars(node->value(), node->value() + node->value_size(), out);
             return out;
         }

--- a/include/exml.hrl
+++ b/include/exml.hrl
@@ -6,7 +6,8 @@
 -ifndef(EXML_HEADER).
 -define(EXML_HEADER, true).
 
--record(xmlcdata, {content = [] :: iodata()}).
+-record(xmlcdata, {content = [] :: iodata(),
+                   style = escaped :: escaped | cdata}).
 
 -record(xmlel, {name :: binary(),
                 attrs = [] :: [exml:attr()],

--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,9 @@
     {doc, #{provider => ex_doc}}
 ]}.
 {ex_doc, [
-     {extras, [<<"README.md">>, <<"LICENSE">>]},
+     {source_url, <<"https://github.com/esl/exml">>},
      {main, <<"readme">>},
-     {source_url, <<"https://github.com/esl/exml">>}
+     {extras, [{'README.md', #{title => <<"README">>}},
+               {'LICENSE', #{title => <<"License">>}}
+              ]}
 ]}.

--- a/src/exml.erl
+++ b/src/exml.erl
@@ -27,9 +27,17 @@
 
 -type attr() :: {binary(), binary()}.
 -type cdata() :: #xmlcdata{}.
+%% CDATA record. Printing escaping rules defaults to escaping character-wise.
+%%
+%% Escaping rules:
+%% <ul>
+%%   <li>`escaped': escapes all characters by regular `&' control escaping.</li>
+%%   <li>`cdata': wraps the entire string into a `<![CDATA[]]>' section.</li>
+%% </ul>
 -type element() :: #xmlel{}.
 -type item() :: element() | attr() | cdata() | exml_stream:start() | exml_stream:stop().
 -type prettify() :: pretty | not_pretty.
+%% Printing indentation rule, see `to_iolist/2'.
 
 %% @doc Calculate the length of the original XML payload
 -spec xml_size(item() | [item()]) -> non_neg_integer().
@@ -56,7 +64,7 @@ xml_size({Key, Value}) when is_binary(Key) ->
     + 4 % ="" and whitespace before
     + byte_size(Value).
 
-%% @doc Sort in ascending order a list of xml `t:item()'.
+%% @doc Sort in ascending order a list of xml `t:item/0'.
 %%
 %% Sorting is defined as calling `lists:sort/1' at:
 %% <ul>
@@ -109,7 +117,7 @@ to_iolist(Element) ->
 to_pretty_iolist(Element) ->
     to_iolist(Element, pretty).
 
-%% @doc Parses a binary or a list of binaries into an XML `t:element()'.
+%% @doc Parses a binary or a list of binaries into an XML `t:element/0'.
 -spec parse(binary() | [binary()]) -> {ok, element()} | {error, any()}.
 parse(XML) ->
     exml_nif:parse(XML).

--- a/src/exml.erl
+++ b/src/exml.erl
@@ -37,8 +37,8 @@ xml_size([]) ->
     0;
 xml_size([Elem | Rest]) ->
     xml_size(Elem) + xml_size(Rest);
-xml_size(#xmlcdata{ content = Content }) ->
-    iolist_size(exml_nif:escape_cdata(Content));
+xml_size(#xmlcdata{content = Content, style = Style}) ->
+    iolist_size(exml_nif:escape_cdata(Content, Style));
 xml_size(#xmlel{ name = Name, attrs = Attrs, children = [] }) ->
     3 % Self-closing: </>
     + byte_size(Name) + xml_size(Attrs);
@@ -129,8 +129,8 @@ to_iolist(#xmlstreamstart{name = Name, attrs = Attrs}, _Pretty) ->
     [Front, $>];
 to_iolist(#xmlstreamend{name = Name}, _Pretty) ->
     [<<"</">>, Name, <<">">>];
-to_iolist(#xmlcdata{content = Content}, _Pretty) ->
-    exml_nif:escape_cdata(Content);
+to_iolist(#xmlcdata{content = Content, style = Style}, _Pretty) ->
+    exml_nif:escape_cdata(Content, Style);
 to_iolist([Element], Pretty) ->
     to_iolist(Element, Pretty);
 to_iolist([#xmlstreamstart{name = Name, attrs = Attrs} | Tail] = Elements, Pretty) ->

--- a/src/exml_nif.erl
+++ b/src/exml_nif.erl
@@ -5,12 +5,12 @@
 
 -module(exml_nif).
 
--nifs([create/2, escape_cdata/1, to_binary/2, parse/1, parse_next/2, reset_parser/1]).
+-nifs([create/2, escape_cdata/2, to_binary/2, parse/1, parse_next/2, reset_parser/1]).
 
 -type parser() :: term().
 -type stream_element() :: exml:element() | exml_stream:start() | exml_stream:stop().
 
--export([create/2, parse/1, parse_next/2, escape_cdata/1,
+-export([create/2, parse/1, parse_next/2, escape_cdata/2,
          to_binary/2, reset_parser/1]).
 -export_type([parser/0, stream_element/0]).
 
@@ -44,8 +44,8 @@ load() ->
 create(_, _) ->
     erlang:nif_error(not_loaded).
 
--spec escape_cdata(Bin :: iodata()) -> binary().
-escape_cdata(_Bin) ->
+-spec escape_cdata(Bin :: iodata(), atom()) -> binary().
+escape_cdata(_Bin, _Style) ->
      erlang:nif_error(not_loaded).
 
 -spec to_binary(Elem :: exml:element(), pretty | not_pretty) -> binary().

--- a/src/exml_nif.erl
+++ b/src/exml_nif.erl
@@ -8,11 +8,9 @@
 -nifs([create/2, escape_cdata/2, to_binary/2, parse/1, parse_next/2, reset_parser/1]).
 
 -type parser() :: term().
--type stream_element() :: exml:element() | exml_stream:start() | exml_stream:stop().
 
 -export([create/2, parse/1, parse_next/2, escape_cdata/2,
          to_binary/2, reset_parser/1]).
--export_type([parser/0, stream_element/0]).
 
 -on_load(load/0).
 
@@ -40,7 +38,7 @@ load() ->
     erlang:load_nif(filename:join(PrivDir, ?MODULE_STRING), none).
 
 -spec create(MaxChildSize :: non_neg_integer(), InfiniteStream :: boolean()) ->
-                    {ok, parser()} | {error, Reason :: any()}.
+    {ok, parser()} | {error, Reason :: any()}.
 create(_, _) ->
     erlang:nif_error(not_loaded).
 
@@ -57,8 +55,8 @@ parse(_) ->
     erlang:nif_error(not_loaded).
 
 -spec parse_next(parser(), Data :: binary() | [binary()]) ->
-                        {ok, stream_element() | undefined, non_neg_integer()} |
-                        {error, Reason :: any()}.
+    {ok, exml_stream:element() | undefined, non_neg_integer()} |
+    {error, Reason :: any()}.
 parse_next(_, _) ->
     erlang:nif_error(not_loaded).
 

--- a/test/exml_tests.erl
+++ b/test/exml_tests.erl
@@ -27,6 +27,12 @@ size_of_escaped_characters_test() ->
     Raw = <<"<a>&amp;</a>">>,
     ?assertEqual(iolist_size(Raw), exml:xml_size(parse(Raw))).
 
+cdata_size_of_escaped_characters_test() ->
+    Raw = <<"<a><![CDATA[some stuff]]></a>">>,
+    CData = #xmlcdata{content = <<"some stuff">>, style = cdata},
+    Final = #xmlel{name = <<"a">>, children = [CData]},
+    ?assertEqual(iolist_size(Raw), exml:xml_size(Final)).
+
 size_of_exml_with_cdata_test() ->
     Raw = <<"<a><![CDATA[ Within this Character Data block I can
             use double dashes as much as I want (along with <, &, ', and \")]]></a>">>,


### PR DESCRIPTION
Expose a way to select cdata to be printed as an escaped string or as a CDATA[] section. The latter can make the string considerably smaller when there is a lot of information that needs to be escaped, for example when printing URLs.

So that this package:

```xml
<name>
  <![CDATA[{"one":1,"two":"bis","three":["raz","dwa","trzy"]}]]>
</name>
```

Doesn’t become this one when printing (which is not only unreadable but also bigger):
```xml
<name>
  {&quot;one&quot;:1,&quot;three&quot;:[&quot;raz&quot;,&quot;dwa&quot;,&quot;trzy&quot;],&quot
;two&quot;:&quot;bis&quot;}
</name>
```