### PR TITLE
Type improvements

### DIFF
--- a/c_src/exml.cpp
+++ b/c_src/exml.cpp
@@ -583,9 +583,10 @@ static ERL_NIF_TERM parse_next(ErlNifEnv *env, int argc,
   }
 
   if (error_msg) {
-    return enif_make_tuple2(
-        env, atom_error,
-        enif_make_string(env, error_msg, ERL_NIF_LATIN1));
+    ERL_NIF_TERM error_message =
+            to_subbinary(ctx, (const unsigned char *)error_msg, strlen(error_msg));
+
+    return enif_make_tuple2(env, atom_error, error_message);
   }
 
   return enif_make_tuple3(
@@ -608,9 +609,12 @@ static ERL_NIF_TERM parse(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     return enif_make_tuple2(env, atom_ok, element);
   }
 
-  return enif_make_tuple2(
-      env, atom_error,
-      enif_make_string(env, result.error_message.c_str(), ERL_NIF_LATIN1));
+  ERL_NIF_TERM error_message =
+        to_subbinary(ctx,
+                     (const unsigned char *)result.error_message.c_str(),
+                     result.error_message.size());
+
+  return enif_make_tuple2(env, atom_error, error_message);
 }
 
 static ERL_NIF_TERM escape_cdata(ErlNifEnv *env, int argc,

--- a/include/exml.hrl
+++ b/include/exml.hrl
@@ -11,7 +11,7 @@
 
 -record(xmlel, {name :: binary(),
                 attrs = #{} :: exml:attrs(),
-                children =  [] :: [exml:element() | exml:cdata()]}).
+                children = [] :: [exml:child()]}).
 
 %% Implementation of the exmlAssertEqual/2 macro is a modification of
 %% https://github.com/erszcz/rxml/commit/e8483408663f0bc2af7896e786c1cdea2e86e43d#diff-2cb5d18741df32f4ead70c21fdd221d1

--- a/src/exml.erl
+++ b/src/exml.erl
@@ -28,13 +28,11 @@
          remove_attr/2,
          xml_sort/1]).
 
--export_type([attr/0,
-              attrs/0,
+-export_type([attrs/0,
               cdata/0,
               element/0,
               item/0]).
 
--type attr() :: {binary(), binary()}.
 -type attrs() :: #{binary() => binary()}.
 -type cdata() :: #xmlcdata{}.
 %% CDATA record. Printing escaping rules defaults to escaping character-wise.
@@ -45,7 +43,7 @@
 %%   <li>`cdata': wraps the entire string into a `<![CDATA[]]>' section.</li>
 %% </ul>
 -type element() :: #xmlel{}.
--type item() :: element() | attr() | cdata() | exml_stream:start() | exml_stream:stop().
+-type item() :: element() | cdata() | exml_stream:start() | exml_stream:stop().
 -type prettify() :: pretty | not_pretty.
 %% Printing indentation rule, see `to_iolist/2'.
 
@@ -87,7 +85,6 @@ xml_size({Key, Value}) when is_binary(Key) ->
 %% https://github.com/erszcz/rxml/commit/e8483408663f0bc2af7896e786c1cdea2e86e43d
 -spec xml_sort([item()]) -> [item()];
               (element()) -> element();
-              (attr()) -> attr();
               (cdata()) -> cdata();
               (exml_stream:start()) -> exml_stream:start();
               (exml_stream:stop()) -> exml_stream:stop().
@@ -101,8 +98,6 @@ xml_sort(#xmlstreamstart{} = StreamStart) ->
     StreamStart;
 xml_sort(#xmlstreamend{} = StreamEnd) ->
     StreamEnd;
-xml_sort({Key, Value}) ->
-    {Key, Value};
 xml_sort(Elements) when is_list(Elements) ->
     lists:sort([ xml_sort(E) || E <- Elements ]).
 

--- a/src/exml.erl
+++ b/src/exml.erl
@@ -31,6 +31,7 @@
 -export_type([attrs/0,
               cdata/0,
               element/0,
+              child/0,
               item/0]).
 
 -type attrs() :: #{binary() => binary()}.
@@ -44,6 +45,7 @@
 %% </ul>
 -type element() :: #xmlel{}.
 -type item() :: element() | cdata() | exml_stream:start() | exml_stream:stop().
+-type child() :: element() | cdata().
 -type prettify() :: pretty | not_pretty.
 %% Printing indentation rule, see `to_iolist/2'.
 

--- a/src/exml_stream.erl
+++ b/src/exml_stream.erl
@@ -69,7 +69,7 @@ new_parser(Opts)->
 %%
 %% If successful, returns parsed elements and a new parser with updated buffers.
 -spec parse(parser(), binary()) ->
-    {ok, parser(), [element()]} | {error, Reason :: iodata()}.
+    {ok, parser(), [element()]} | {error, Reason :: binary()}.
 parse(Parser, Input) when is_binary(Input) ->
     #parser{event_parser = EventParser, buffer = OldBuf} = Parser,
     Buffer = OldBuf ++ [Input],

--- a/src/exml_stream.erl
+++ b/src/exml_stream.erl
@@ -31,7 +31,7 @@
 %% `#xmlstreamend{}' record.
 -type parser() :: #parser{}.
 %% `#parser{}' record. Keeps track of unparsed buffers.
--type element() :: exml:element() | exml_stream:start() | exml_stream:stop().
+-type element() :: exml:element() | start() | stop().
 %% One of `t:exml:element/0', `t:start/0', or `t:stop/0'.
 
 -type parser_opt() :: {infinite_stream, boolean()} | {max_element_size, non_neg_integer()}.
@@ -69,7 +69,7 @@ new_parser(Opts)->
 %%
 %% If successful, returns parsed elements and a new parser with updated buffers.
 -spec parse(parser(), binary()) ->
-    {ok, parser(), [exml_stream:element()]} | {error, Reason :: any()}.
+    {ok, parser(), [element()]} | {error, Reason :: iodata()}.
 parse(Parser, Input) when is_binary(Input) ->
     #parser{event_parser = EventParser, buffer = OldBuf} = Parser,
     Buffer = OldBuf ++ [Input],

--- a/test/exml_stream_tests.erl
+++ b/test/exml_stream_tests.erl
@@ -188,45 +188,45 @@ stream_max_opening_tag_size_test() ->
     ?assertMatch({ok, _Parser1, [#xmlstreamstart{},
                                  #xmlel{}]}, exml_stream:parse(Parser0, <<"<stream89><a></a>">>)),
     {ok, Parser2} = exml_stream:new_parser([{max_element_size, 9}]),
-    ?assertEqual({error, "element too big"}, exml_stream:parse(Parser2, <<"<stream89><a></a>">>)).
+    ?assertEqual({error, <<"element too big">>}, exml_stream:parse(Parser2, <<"<stream89><a></a>">>)).
 
 stream_max_element_size_test() ->
     {ok, Parser0} = exml_stream:new_parser([{max_element_size, 10}]),
     {ok, Parser1, Elements0} = exml_stream:parse(Parser0, <<"<stream><a></a>">>),
     ?assertMatch([#xmlstreamstart{}, #xmlel{}], Elements0),
-    ?assertEqual({error, "element too big"}, exml_stream:parse(Parser1, <<"<c><d/></c>">>)).
+    ?assertEqual({error, <<"element too big">>}, exml_stream:parse(Parser1, <<"<c><d/></c>">>)).
 
 stream_max_text_element_size_test() ->
     {ok, Parser0} = exml_stream:new_parser([{max_element_size, 10}]),
     {ok, Parser1, Elements0} = exml_stream:parse(Parser0, <<"<stream><a>123</a><b>123</b>">>),
     ?assertMatch([#xmlstreamstart{}, #xmlel{}, #xmlel{}], Elements0),
-    ?assertEqual({error, "element too big"}, exml_stream:parse(Parser1, <<"<c>1234</c>">>)).
+    ?assertEqual({error, <<"element too big">>}, exml_stream:parse(Parser1, <<"<c>1234</c>">>)).
 
 stream_max_incomplete_element_size_test() ->
     {ok, Parser0} = exml_stream:new_parser([{max_element_size, 10}]),
     {ok, Parser1, Elements0} = exml_stream:parse(Parser0, <<"<stream><a>123</a><b>123</b>">>),
     ?assertMatch([#xmlstreamstart{}, #xmlel{}, #xmlel{}], Elements0),
     %% Element <c> has 10 characters, but it's incomplete, so it would be too big
-    ?assertEqual({error, "element too big"}, exml_stream:parse(Parser1, <<"<c>1234</c">>)).
+    ?assertEqual({error, <<"element too big">>}, exml_stream:parse(Parser1, <<"<c>1234</c">>)).
 
 stream_max_chunked_element_size_test() ->
     {ok, Parser0} = exml_stream:new_parser([{max_element_size, 10}]),
     {ok, Parser1, Elements0} = exml_stream:parse(Parser0, <<"<stream><a><b/>">>),
     ?assertMatch([#xmlstreamstart{}], Elements0),
-    ?assertEqual({error, "element too big"}, exml_stream:parse(Parser1, <<"   ">>)).
+    ?assertEqual({error, <<"element too big">>}, exml_stream:parse(Parser1, <<"   ">>)).
 
 stream_max_root_element_size_test() ->
     {ok, Parser0} = exml_stream:new_parser([{max_element_size, 10}, {infinite_stream, true}]),
     {ok, Parser1, Elements0} = exml_stream:parse(Parser0, <<"<a>123</a><b>123</b>">>),
     ?assertMatch([#xmlel{}, #xmlel{}], Elements0),
-    ?assertEqual({error, "element too big"}, exml_stream:parse(Parser1, <<"<c><d/></c>">>)).
+    ?assertEqual({error, <<"element too big">>}, exml_stream:parse(Parser1, <<"<c><d/></c>">>)).
 
 stream_max_incomplete_root_element_size_test() ->
     {ok, Parser0} = exml_stream:new_parser([{max_element_size, 10}, {infinite_stream, true}]),
     {ok, Parser1, Elements0} = exml_stream:parse(Parser0, <<"<a>123</a><b>123</b>">>),
     ?assertMatch([#xmlel{}, #xmlel{}], Elements0),
     %% Element <c> has 10 characters, but it will have at least one more character
-    ?assertEqual({error, "element too big"}, exml_stream:parse(Parser1, <<"<c>1234</c">>)).
+    ?assertEqual({error, <<"element too big">>}, exml_stream:parse(Parser1, <<"<c>1234</c">>)).
 
 infinite_stream_partial_chunk_test() ->
     {ok, Parser0} = exml_stream:new_parser([{infinite_stream, true}]),

--- a/test/exml_tests.erl
+++ b/test/exml_tests.erl
@@ -52,11 +52,6 @@ sort_xmlel_identity_test() ->
            },
     ?assertEqual(El, exml:xml_sort(El)).
 
-sort_xmlel_attributes_test() ->
-    Attrs = [{<<"attr1">>, <<"foo">>}, {<<"attr2">>, <<"bar">>}],
-    ToOrder = [{<<"attr2">>, <<"bar">>}, {<<"attr1">>, <<"foo">>}],
-    ?assertEqual(Attrs, exml:xml_sort(ToOrder)).
-
 remove_cdata_test() ->
     Attrs = #{<<"attr1">> => <<"foo">>, <<"attr2">> => <<"bar">>},
     Child1 = #xmlel{name = <<"el1">>, attrs = Attrs},


### PR DESCRIPTION
First commit really should be merged, as strong typing tools return warnings because the spec declared it is anything but we always use it as `iodata()`. The second commit was just me thinking that everywhere we deal with binaries, so why only here it is a list, we can use binaries for this too.