### PR TITLE
Fix llvm19 builds

### DIFF
--- a/c_src/exml.cpp
+++ b/c_src/exml.cpp
@@ -17,7 +17,7 @@
 #include <thread>
 #include <vector>
 
-using ustring = std::basic_string<unsigned char>;
+using ustring = std::vector<unsigned char>;
 
 class xml_document {
 public:
@@ -512,8 +512,7 @@ static ERL_NIF_TERM parse_next(ErlNifEnv *env, int,
         error_msg = "element too big";
       } else {
         auto name_tag = node_name(doc.impl.first_node());
-        parser->stream_tag =
-          ustring{std::get<0>(name_tag), std::get<1>(name_tag)};
+        parser->stream_tag = ustring(std::get<0>(name_tag), std::get<0>(name_tag) + std::get<1>(name_tag));
         element = make_stream_start_tuple(ctx, doc.impl.first_node());
       }
     }
@@ -525,7 +524,7 @@ static ERL_NIF_TERM parse_next(ErlNifEnv *env, int,
     if (parseOpenRes.has_error)
       return false;
     auto tag_name = node_name(doc.impl.first_node());
-    return ustring{std::get<0>(tag_name), std::get<1>(tag_name)} ==
+    return ustring(std::get<0>(tag_name), std::get<0>(tag_name) + std::get<1>(tag_name)) ==
            parser->stream_tag;
   };
 

--- a/c_src/exml.cpp
+++ b/c_src/exml.cpp
@@ -38,7 +38,7 @@ public:
     return with_error_handling([&] { return impl.parse<flags>(text); });
   }
 
-  const void clear() { impl.clear(); }
+  void clear() { impl.clear(); }
 
   rapidxml::xml_document<unsigned char> impl;
 
@@ -249,9 +249,6 @@ ERL_NIF_TERM make_attr_tuple(ParseCtx &ctx,
 }
 
 ERL_NIF_TERM get_attributes(ParseCtx &ctx, rapidxml::xml_node<unsigned char> *node) {
-  std::vector<ERL_NIF_TERM> &attrs = Parser::term_buffer;
-  std::size_t begin = attrs.size();
-
   ERL_NIF_TERM attrs_term = enif_make_new_map(ctx.env);
 
   for (rapidxml::xml_attribute<unsigned char> *attr = node->first_attribute();
@@ -437,11 +434,11 @@ bool has_stream_closing_tag(Parser *parser, std::size_t offset) {
 } // namespace
 
 extern "C" {
-static void delete_parser(ErlNifEnv *env, void *parser) {
+static void delete_parser(ErlNifEnv *, void *parser) {
   static_cast<Parser *>(parser)->~Parser();
 }
 
-static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
+static int load(ErlNifEnv *env, void **, ERL_NIF_TERM) {
   parser_type = enif_open_resource_type(
       env, "exml_nif", "parser", &delete_parser, ERL_NIF_RT_CREATE, nullptr);
   atom_ok = enif_make_atom(env, "ok");
@@ -461,11 +458,11 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
   return 0;
 }
 
-static void unload(ErlNifEnv *env, void *priv_data) {
+static void unload(ErlNifEnv *, void *) {
   return;
 }
 
-static ERL_NIF_TERM create(ErlNifEnv *env, int argc,
+static ERL_NIF_TERM create(ErlNifEnv *env, int,
                            const ERL_NIF_TERM argv[]) {
   void *mem = enif_alloc_resource(parser_type, sizeof(Parser));
   Parser *parser = new (mem) Parser;
@@ -482,7 +479,7 @@ static ERL_NIF_TERM create(ErlNifEnv *env, int argc,
   return enif_make_tuple2(env, atom_ok, term);
 }
 
-static ERL_NIF_TERM parse_next(ErlNifEnv *env, int argc,
+static ERL_NIF_TERM parse_next(ErlNifEnv *env, int,
                                const ERL_NIF_TERM argv[]) {
   Parser *parser;
   if (!enif_get_resource(env, argv[0], parser_type,
@@ -594,7 +591,7 @@ static ERL_NIF_TERM parse_next(ErlNifEnv *env, int argc,
       enif_make_uint64(env, result.rest - Parser::buffer.data()));
 }
 
-static ERL_NIF_TERM parse(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM parse(ErlNifEnv *env, int, const ERL_NIF_TERM argv[]) {
   Parser parser;
   parser.copy_buffer(env, argv[0]);
   Parser::term_buffer.clear();
@@ -617,7 +614,7 @@ static ERL_NIF_TERM parse(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
   return enif_make_tuple2(env, atom_error, error_message);
 }
 
-static ERL_NIF_TERM escape_cdata(ErlNifEnv *env, int argc,
+static ERL_NIF_TERM escape_cdata(ErlNifEnv *env, int,
                                  const ERL_NIF_TERM argv[]) {
   ErlNifBinary bin;
   if (!enif_inspect_iolist_as_binary(env, argv[0], &bin))
@@ -636,7 +633,7 @@ static ERL_NIF_TERM escape_cdata(ErlNifEnv *env, int argc,
   return node_to_binary(env, node, rapidxml::print_no_indenting);
 }
 
-static ERL_NIF_TERM to_binary(ErlNifEnv *env, int argc,
+static ERL_NIF_TERM to_binary(ErlNifEnv *env, int,
                               const ERL_NIF_TERM argv[]) {
   int arity;
   const ERL_NIF_TERM *xmlel;
@@ -657,7 +654,7 @@ static ERL_NIF_TERM to_binary(ErlNifEnv *env, int argc,
   return node_to_binary(env, doc.impl, flags);
 }
 
-static ERL_NIF_TERM reset_parser(ErlNifEnv *env, int argc,
+static ERL_NIF_TERM reset_parser(ErlNifEnv *env, int,
                                  const ERL_NIF_TERM argv[]) {
   Parser *parser;
   if (!enif_get_resource(env, argv[0], parser_type,
@@ -669,9 +666,9 @@ static ERL_NIF_TERM reset_parser(ErlNifEnv *env, int argc,
 }
 
 static ErlNifFunc nif_funcs[] = {
-    {"create", 2, create},         {"parse", 1, parse},
-    {"parse_next", 2, parse_next}, {"escape_cdata", 2, escape_cdata},
-    {"to_binary", 2, to_binary},   {"reset_parser", 1, reset_parser}};
+    {"create", 2, create, 0},         {"parse", 1, parse, 0},
+    {"parse_next", 2, parse_next, 0}, {"escape_cdata", 2, escape_cdata, 0},
+    {"to_binary", 2, to_binary, 0},   {"reset_parser", 1, reset_parser, 0}};
 }
 
 ERL_NIF_INIT(exml_nif, nif_funcs, &load, nullptr, nullptr, &unload)

--- a/c_src/rapidxml_print.hpp
+++ b/c_src/rapidxml_print.hpp
@@ -117,7 +117,7 @@ namespace rapidxml
 
         // Print attributes of the node
         template<class OutIt, class Ch>
-        inline OutIt print_attributes(OutIt out, const xml_node<Ch> *node, int flags)
+        inline OutIt print_attributes(OutIt out, const xml_node<Ch> *node, int)
         {
             for (xml_attribute<Ch> *attribute = node->first_attribute(); attribute; attribute = attribute->next_attribute())
             {

--- a/rebar.config
+++ b/rebar.config
@@ -20,6 +20,8 @@
             {"CXXFLAGS", "$CXXFLAGS -O3 -std=c++11 -g -Wall -Wextra -fPIC --coverage"},
             {"LDFLAGS", "$LDFLAGS --coverage"}
         ]},
+        {eunit_opts, [verbose]},
+        {cover_opts, [verbose]},
         {cover_enabled, true},
         {cover_export_enabled, true}
     ]}


### PR DESCRIPTION
See https://libcxx.llvm.org/ReleaseNotes/19.html#deprecations-and-removals: 
> The base template for std::char_traits has been removed in LLVM 19. If you are using std::char_traits with types other than char, wchar_t, char8_t, char16_t, char32_t or a custom character type for which you specialized std::char_traits, your code will stop working. The Standard does not mandate that a base template is provided, and such a base template is bound to be incorrect for some types, which could currently cause unexpected behavior while going undetected.

Then https://github.com/esl/exml/blob/3f63a631cc2de20f85e3ddcce289056af4b9f0e5/c_src/exml.cpp#L20
`using ustring = std::basic_string<unsigned char>;`
That unsigned char is not a valid char_traits and will fail to compile. C++20 came up with a new type called char8_t which is undefined behaviour to cast to unsigned char because "dealing with UTF8 encoding safely is hard", so it broke backwards compatibility.

But OTP uses unsigned char for everything binaries, and it is undefined behaviour to convert from one to the other in C++.

Hence `exml` breaks under LLVM 19, that is, XCode 16.3, that is, the update apple release this week.

This PR fixes it by simply using a vector of `unsigned char`s instead of the `basic_string`. Theoretically the basic string is a lighter-weight abstraction but I doubt the compiler wouldn't know how to optimise that.

This PR also removes some unused variables.